### PR TITLE
Allow build on Mac and simplify conan file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,8 +102,17 @@ if( UNIX )
 
 
   if (APPLE)
-    find_library(GDBM libgdbm.a PATHS /usr/local/Cellar/gdbm/lib /usr/local/opt/gdbm/lib)
-    set(GDBM_opt "--with-gdbm-dir=${GDBM}")
+    # Brew installs in there
+    # Another option is to find_package(brew brew) then execute_process brew --prefix gdbm
+    # Without NO_DEFAULT_PATH it finds my system one at /usr/local/lib/
+    find_library(GDBM libgdbm.a PATHS /usr/local/opt/gdbm/lib NO_DEFAULT_PATH)
+    if(NOT GDBM)
+      message(FATAL_ERROR "Please use Homebrew to install GDBM: `brew install gdbm`")
+    endif()
+    message(STATUS "Found libgdbm at ${GDBM}")
+    get_filename_component(GDBM_DIR "${GDBM}/../.." ABSOLUTE)
+    set(GDBM_opt "--with-gdbm-dir=${GDBM_DIR}")
+    message(STATUS "Configuring Ruby with '${GDBM_opt}")
   endif()
 
     # KSB: For Mac, you may need to install some things...
@@ -198,6 +207,9 @@ else()
   )
 endif()
 
+# TODO: This is triggered before ExternalProject_Add finishes... so useless
+# Move to Conan's side? Or try to use TEST_COMMAND i ExternalProject_Add
+message("${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/bin/ruby -r openssl -e print OpenSSL::OPENSSL_VERSION[/\\d+\\.\\d+\\.\\d+[a-z]/]")
 execute_process(COMMAND "${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/bin/ruby" -r openssl -e "print OpenSSL::OPENSSL_VERSION[/\\d+\\.\\d+\\.\\d+[a-z]/]"
   OUTPUT_VARIABLE RUBY_OPENSSL_VERSION
   OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,8 @@ if( UNIX )
     CONFIGURE_COMMAND pwd && sh -c "pwd && ./configure --with-static-linked-ext ${RUBY_EXT_CONFIG} ${GDBM_opt} --disable-install-doc --prefix=${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install --with-zlib-dir=${CURRENT_CONAN_ZLIB_ROOT} --with-openssl-dir=${CURRENT_CONAN_OPENSSL_ROOT}"
     #    BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} Use default BUILD_COMMAND for now
     INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install && sh -c "cp ./rbconfig.rb ${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/lib/ruby/2.5.0/." && sh -c "rm -rf ./ext/-test-" && sh -c "mkdir ${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/lib/ext" && sh -c "mkdir ${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/lib/enc" && sh -c "find ./ext -name '*.a' | xargs -I {} cp {} ${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/lib/ext/" && sh -c "find ./enc -name '*.a' | xargs -I {} cp {} ${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/lib/enc"
+    # Run a ruby script to ensure we linked against the right OpenSSL
+    TEST_COMMAND sh -c "${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/bin/ruby ${CMAKE_SOURCE_DIR}/test_openssl_version.rb ${OPENSSL_VERSION}"
   )
   find_file( RUBY_CONFIG_INCLUDE_DIR config.h PATHS "${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/include/" )
 
@@ -178,6 +180,8 @@ else()
       COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib
       COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_x64/x64/$<CONFIG>/libffi.lib ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib/libffi.lib
       #COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_x64/x64/$<CONFIG>/libffi.pdb ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib/libffi.pdb
+    # Run a ruby script to ensure we linked against the right OpenSSL
+    TEST_COMMAND cmd /C "${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/bin/ruby ${CMAKE_SOURCE_DIR}/test_openssl_version.rb ${OPENSSL_VERSION}"
   )
 
   set(CURRENT_CONAN_LIBFFI_ROOT ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/)
@@ -206,21 +210,3 @@ else()
     INSTALL_COMMAND ""
   )
 endif()
-
-# TODO: This is triggered before ExternalProject_Add finishes... so useless
-# Move to Conan's side? Or try to use TEST_COMMAND i ExternalProject_Add
-message("${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/bin/ruby -r openssl -e print OpenSSL::OPENSSL_VERSION[/\\d+\\.\\d+\\.\\d+[a-z]/]")
-execute_process(COMMAND "${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/bin/ruby" -r openssl -e "print OpenSSL::OPENSSL_VERSION[/\\d+\\.\\d+\\.\\d+[a-z]/]"
-  OUTPUT_VARIABLE RUBY_OPENSSL_VERSION
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-# Only keep the version: not needed; we do it in ruby above
-#STRING(REGEX REPLACE "^OpenSSL +([0-9]+\\.[0-9]+\\.[0-9]+[a-z]) +.*" "\\1" RUBY_OPENSSL_VERSION "${RUBY_OPENSSL_VERSION}")
-
-if(RUBY_OPENSSL_VERSION VERSION_EQUAL OPENSSL_VERSION)
-  message(STATUS "Checking Ruby OpenSSL version: OK, ruby is built against the right OpenSSL version '${RUBY_OPENSSL_VERSION}' (expected == '${OPENSSL_VERSION}')")
-else()
-  message(WARNING "Ruby doesn't appear to be built against the right OpenSSL version, built against '${RUBY_OPENSSL_VERSION}' while we expected == '${OPENSSL_VERSION}'")
-endif()
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,12 @@ if( UNIX )
   #  set(RUBY_EXT_CONFIG "--with-openssl-dir=/usr --with-readline-dir=/usr --with-zlib-dir=/usr")
   #endif()
 
+
+  if (APPLE)
+    find_library(GDBM libgdbm.a PATHS /usr/local/Cellar/gdbm /usr/local/opt/gdbm/lib)
+    set(GDBM_opt "--with-gdbm-dir=${GDBM}")
+  endif()
+
   # KSB: For Mac, you may need to install some things...
   # brew install homebrew/dupes/zlib
   # brew link --overwrite --force homebrew/dupes/zlib
@@ -107,7 +113,7 @@ if( UNIX )
     # The 'nodynamic' modules patch fails to build in any way on Unix, with 2.5.x, so we aren't using it (at the moment anyhow)
     PATCH_COMMAND pwd && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/Ruby.patch # && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/Ruby.nodynamic.patch
     BUILD_IN_SOURCE 1
-    CONFIGURE_COMMAND pwd && sh -c "pwd && ./configure --with-static-linked-ext ${RUBY_EXT_CONFIG} --disable-install-doc --prefix=${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install --with-zlib-dir=${CURRENT_CONAN_ZLIB_ROOT} --with-openssl-dir=${CURRENT_CONAN_OPENSSL_ROOT}"
+    CONFIGURE_COMMAND pwd && sh -c "pwd && ./configure --with-static-linked-ext ${RUBY_EXT_CONFIG} ${GDBM_opt} --disable-install-doc --prefix=${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install --with-zlib-dir=${CURRENT_CONAN_ZLIB_ROOT} --with-openssl-dir=${CURRENT_CONAN_OPENSSL_ROOT}"
     #    BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} Use default BUILD_COMMAND for now
     INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install && sh -c "cp ./rbconfig.rb ${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/lib/ruby/2.5.0/." && sh -c "rm -rf ./ext/-test-" && sh -c "mkdir ${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/lib/ext" && sh -c "mkdir ${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/lib/enc" && sh -c "find ./ext -name '*.a' | xargs -I {} cp {} ${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/lib/ext/" && sh -c "find ./enc -name '*.a' | xargs -I {} cp {} ${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/lib/enc"
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ if( UNIX )
 
 
   if (APPLE)
-    find_library(GDBM libgdbm.a PATHS /usr/local/Cellar/gdbm /usr/local/opt/gdbm/lib)
+    find_library(GDBM libgdbm.a PATHS /usr/local/Cellar/gdbm/lib /usr/local/opt/gdbm/lib)
     set(GDBM_opt "--with-gdbm-dir=${GDBM}")
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,12 @@ if (INTEGRATED_CONAN)
   conan_add_remote(NAME bincrafters
     URL https://api.bintray.com/conan/bincrafters/public-conan)
 
+
+  set(CONAN_BUILD "missing")
+  if (APPLE)
+    list(APPEND CONAN_BUILD "zlib")
+  endif()
+
   conan_cmake_run(REQUIRES
     OpenSSL/${OPENSSL_VERSION}@conan/stable
     ruby_installer/2.5.1@bincrafters/stable
@@ -36,7 +42,7 @@ if (INTEGRATED_CONAN)
 
     BASIC_SETUP CMAKE_TARGETS NO_OUTPUT_DIRS
     GENERATORS cmake_find_package
-    BUILD missing
+    BUILD ${CONAN_BUILD}
   )
 else()
   include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
@@ -100,7 +106,7 @@ if( UNIX )
     set(GDBM_opt "--with-gdbm-dir=${GDBM}")
   endif()
 
-  # KSB: For Mac, you may need to install some things...
+    # KSB: For Mac, you may need to install some things...
   # brew install homebrew/dupes/zlib
   # brew link --overwrite --force homebrew/dupes/zlib
   # brew install autoconf automake libtool

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if (INTEGRATED_CONAN)
   # Download automatically, you can also just copy the conan.cmake file
   if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
     message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
-    file(DOWNLOAD "https://github.com/conan-io/cmake-conan/raw/v0.13/conan.cmake"
+    file(DOWNLOAD "https://github.com/conan-io/cmake-conan/raw/v0.14/conan.cmake"
       "${CMAKE_BINARY_DIR}/conan.cmake")
   endif()
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ conan remote add jmarrec https://api.bintray.com/conan/jmarrec/testing
 ```
 $ conan user -p <APIKEY> -r <REMOTE> <USERNAME>
 # eg:
-$ conan user -p <API_KEY> -r testing jmarrec
+$ conan user -p <API_KEY> -r jmarrec jmarrec
 ```
 
 * Add a new package on bintray, eg 'openstudio_ruby'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ A [conan](https://conan.io/) package to build ruby for [OpenStudio](https://gith
 
 **TODO: Once the NREL bintray is up and running, only include the information needed to upload (remove the setup portion) and with the right links**
 
-Full instructions available at: https://docs.conan.io/en/latest/uploading_packages/bintray/uploading_bintray.html
+Full instructions available at [Conan Docs](https://docs.conan.io/en/latest/uploading_packages/bintray/uploading_bintray.html).
+
+Steps:
 
 * Setup a new organization and repo on bintray. For now I didn't add an organization, just a repo, at https://bintray.com/jmarrec/testing
 * Get your API key by clicking on "View Profile"
@@ -16,17 +18,18 @@ $ conan remote add <REMOTE> <YOUR_BINTRAY_REPO_URL>
 # eg:
 $ conan remote add jmarrec https://api.bintray.com/conan/jmarrec/testing
 ```
+
 * Add your API key:
 ```
 $ conan user -p <APIKEY> -r <REMOTE> <USERNAME>
 # eg:
 $ conan user -p <API_KEY> -r testing jmarrec
 ```
+
 * Add a new package on bintray, eg 'openstudio_ruby'
 * Add a new version for the package, eg '2.5.5:testing'
 
-* Build your binaries
-* Upload them to your remote:
+* Build your binaries locally and Upload them to your remote:
 ```
 $ conan create . openstudio_ruby/2.5.5@jmarrec/testing -r jmarrec
 $ conan upload openstudio_ruby/2.5.5@jmarrec/testing -r jmarrec

--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@ Steps:
 * Get your API key by clicking on "View Profile"
 * Add remote to conan client
 ```
-$ conan remote add <REMOTE> <YOUR_BINTRAY_REPO_URL>
+conan remote add <REMOTE> <YOUR_BINTRAY_REPO_URL>
 # eg:
-$ conan remote add jmarrec https://api.bintray.com/conan/jmarrec/testing
+conan remote add jmarrec https://api.bintray.com/conan/jmarrec/testing
 ```
 
 * Add your API key:
 ```
-$ conan user -p <APIKEY> -r <REMOTE> <USERNAME>
+conan user -p <APIKEY> -r <REMOTE> <USERNAME>
 # eg:
-$ conan user -p <API_KEY> -r jmarrec jmarrec
+conan user -p <API_KEY> -r jmarrec jmarrec
 ```
 
 * Add a new package on bintray, eg 'openstudio_ruby'
@@ -31,6 +31,6 @@ $ conan user -p <API_KEY> -r jmarrec jmarrec
 
 * Build your binaries locally and Upload them to your remote:
 ```
-$ conan create . openstudio_ruby/2.5.5@jmarrec/testing -r jmarrec
-$ conan upload openstudio_ruby/2.5.5@jmarrec/testing -r jmarrec
+conan create . openstudio_ruby/2.5.5@jmarrec/testing -r jmarrec
+conan upload openstudio_ruby/2.5.5@jmarrec/testing -r jmarrec
 ```

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,6 +1,6 @@
 import os
 import glob as gb
-from conans import ConanFile, CMake, tools
+from conans import ConanFile, CMake
 
 
 class OpenstudiorubyConan(ConanFile):
@@ -50,7 +50,8 @@ class OpenstudiorubyConan(ConanFile):
         p = found[0]
         abspath = os.path.abspath(os.path.join(p, os.pardir, os.pardir))
         relpath = os.path.relpath(abspath, ".")
-        print("Found config.h in {}".format(relpath))
+        # Add a success (in green) to ensure it did the right thing
+        self.output.success("Found config.h in {}".format(relpath))
         return relpath
 
     def package_info(self):
@@ -58,125 +59,48 @@ class OpenstudiorubyConan(ConanFile):
         # or something
 
         if self.settings.os == "Windows":
-            # self.cpp_info.libs = ['x64-vcruntime140-ruby250-static.lib',
-            #                       "at_exit-x64-mswin64_140.lib",
-            #                       "bigdecimal.lib",
-            #                       "bignum-x64-mswin64_140.lib",
-            #                       "bubblebabble.lib",
-            #                       "bug_3571-x64-mswin64_140.lib",
-            #                       "bug_5832-x64-mswin64_140.lib",
-            #                       "bug_reporter-x64-mswin64_140.lib",
-            #                       "call_without_gvl-x64-mswin64_140.lib",
-            #                       "class-x64-mswin64_140.lib",
-            #                       "compat-x64-mswin64_140.lib",
-            #                       "console.lib",
-            #                       "console-x64-mswin64_140.lib",
-            #                       "continuation.lib",
-            #                       "coverage.lib",
-            #                       "cparse.lib",
-            #                       "date_core.lib",
-            #                       "debug-x64-mswin64_140.lib",
-            #                       "digest.lib",
-            #                       "dlntest.lib",
-            #                       "dln-x64-mswin64_140.lib",
-            #                       "dot.dot-x64-mswin64_140.lib",
-            #                       "empty-x64-mswin64_140.lib",
-            #                       "escape.lib",
-            #                       "etc.lib",
-            #                       "exception-x64-mswin64_140.lib",
-            #                       "fcntl.lib",
-            #                       "fd_setsize-x64-mswin64_140.lib",
-            #                       "fiber.lib",
-            #                       "fiddle.lib",
-            #                       "file-x64-mswin64_140.lib",
-            #                       "float-x64-mswin64_140.lib",
-            #                       "foreach-x64-mswin64_140.lib",
-            #                       "funcall-x64-mswin64_140.lib",
-            #                       "generator.lib",
-            #                       "hash-x64-mswin64_140.lib",
-            #                       "integer-x64-mswin64_140.lib",
-            #                       "internal_ivar-x64-mswin64_140.lib",
-            #                       "iseq_load-x64-mswin64_140.lib",
-            #                       "iter-x64-mswin64_140.lib",
-            #                       "md5.lib",
-            #                       "memory_status-x64-mswin64_140.lib",
-            #                       "method-x64-mswin64_140.lib",
-            #                       "nkf.lib",
-            #                       "nonblock.lib",
-            #                       "notimplement-x64-mswin64_140.lib",
-            #                       "num2int-x64-mswin64_140.lib",
-            #                       "numhash-x64-mswin64_140.lib",
-            #                       "objspace.lib",
-            #                       "openssl.lib",
-            #                       "parser.lib",
-            #                       "path_to_class-x64-mswin64_140.lib",
-            #                       "pathname.lib",
-            #                       "postponed_job-x64-mswin64_140.lib",
-            #                       "printf-x64-mswin64_140.lib",
-            #                       "proc-x64-mswin64_140.lib",
-            #                       "protect-x64-mswin64_140.lib",
-            #                       "psych.lib",
-            #                       "rational-x64-mswin64_140.lib",
-            #                       "rb_fatal-x64-mswin64_140.lib",
-            #                       "recursion-x64-mswin64_140.lib",
-            #                       "regexp-x64-mswin64_140.lib",
-            #                       "resize-x64-mswin64_140.lib",
-            #                       "resolv.lib",
-            #                       "ripper.lib",
-            #                       "rmd160.lib",
-            #                       "scan_args-x64-mswin64_140.lib",
-            #                       "sdbm.lib",
-            #                       "sha1.lib",
-            #                       "sha2.lib",
-            #                       "sizeof.lib",
-            #                       "socket.lib",
-            #                       "stringio.lib",
-            #                       "string-x64-mswin64_140.lib",
-            #                       "strscan.lib",
-            #                       "struct-x64-mswin64_140.lib",
-            #                       "symbol-x64-mswin64_140.lib",
-            #                       "thread_fd_close-x64-mswin64_140.lib",
-            #                       "time-x64-mswin64_140.lib",
-            #                       "tracepoint-x64-mswin64_140.lib",
-            #                       "typeddata-x64-mswin64_140.lib",
-            #                       "update-x64-mswin64_140.lib",
-            #                       "usr-x64-mswin64_140.lib",
-            #                       "wait.lib",
-            #                       "wait_for_single_fd-x64-mswin64_140.lib",
-            #                       "zlib.lib",
-            #                       "libtrans.lib",
-            #                       "libenc.lib"]
-
             libext = "lib"
 
         else:
+            libext = "a"
 
-            # self.cpp_info.libs = ['libruby-static.a', "pathname.a",
-            #                       "objspace.a", "readline.a", "zlib.a",
-            #                       "sizeof.a", "strscan.a", "parser.a",
-            #                       "fiber.a", "cparse.a", "wait.a", "fcntl.a",
-            #                       "coverage.a", "stringio.a", "generator.a",
-            #                       "nonblock.a", "psych.a", "socket.a",
-            #                       "pty.a", "etc.a", "dbm.a", "fiddle.a",
-            #                       'sha2.a', "syslog.a", "sdbm.a", "digest.a",
-            #                       "bigdecimal.a", "console.a",
-            #                       "bubblebabble.a", "ripper.a", 'date_core.a',
-            #                       "nkf.a", "gdbm.a", 'rmd160.a',
-            #                       "continuation.a", "openssl.a", 'sha1.a',
-            #                       'md5.a', "escape.a", "libtrans.a",
-            #                       "libenc.a"]
+        # Note: If you don't specify explicitly self.package_folder, "."
+        # actually already resolves to it when package_info is run
 
-            libext = ".a"
+        # Glob all libraries, keeping only their name (and not the path)
+        glob_pattern = "**/*.{}".format(libext)
+        # glob_pattern = os.path.join(self.package_folder, glob_pattern)
 
+        libs = gb.glob(glob_pattern, recursive=True)
+        if not libs:
+            # Add debug info
+            self.output.info("cwd={}".format(os.path.abspath(".")))
+            self.output.info("Package folder: {}".format(self.package_folder))
+            self.output.error("Globbing: {}".format(glob_pattern))
+            raise "Didn't find the libraries!"
 
-        self.cpp_info.libs = libs = [os.path.basename(x) for x
-                                     in gb.glob("**/*.{}".format(libext),
-                                                recursive=True)]
+        self.output.success("Found {} libs".format(len(libs)))
+
+        # Relative to package folder: no need unless explicitly setting glob
+        # to package_folder above
+        # libs = [os.path.relpath(p, start=self.package_folder) for p in libs]
+
+        # Keep only the names
+        self.cpp_info.libs = [os.path.basename(x) for x in libs]
+
+        # self.cpp_info.libdirs = ['lib', 'lib/ext', 'lib/enc']
+        # Equivalent automatic detection
+        # list of unique folders
+        libdirs = list(set([os.path.dirname(x) for x in libs]))
+        # Sort it by nesting level, smaller first
+        libdirs.sort(key=lambda p: len(os.path.normpath(p).split(os.sep)))
+        self.cpp_info.libdirs = libdirs
+
+        self.output.info("cpp_info.libs = {}".format(self.cpp_info.libs))
 
         # include/ruby-2.5.0/x64-mswin64_140'
         # 'include/ruby-2.5.0/x86_64-linux',
         # 'include/ruby-2.5.0/x86_64-darwin17'
-        self.cpp_info.libdirs = ['lib', 'lib/ext', 'lib/enc']
+
         self.cpp_info.includedirs = ['include', 'include/ruby-2.5.0']
         self.cpp_info.includedirs.append(self.find_config_header())
-

--- a/conanfile.py
+++ b/conanfile.py
@@ -42,7 +42,13 @@ class OpenstudiorubyConan(ConanFile):
         """
         Locate the ruby/config.h which will be in different folders depending
         on the platform
+
+        eg:
+            include/ruby-2.5.0/x64-mswin64_140
+            include/ruby-2.5.0/x86_64-linux
+            include/ruby-2.5.0/x86_64-darwin17
         """
+
         found = gb.glob("**/ruby/config.h", recursive=True)
         if len(found) != 1:
             raise "Didn't find one and one only ruby/config.h"
@@ -55,12 +61,10 @@ class OpenstudiorubyConan(ConanFile):
         return relpath
 
     def package_info(self):
-        # TODO: This can certainly be done better with file globbing
-        # or something
 
+        # We'll glob for this extension
         if self.settings.os == "Windows":
             libext = "lib"
-
         else:
             libext = "a"
 
@@ -74,7 +78,7 @@ class OpenstudiorubyConan(ConanFile):
         libs = gb.glob(glob_pattern, recursive=True)
         if not libs:
             # Add debug info
-            self.output.info("cwd={}".format(os.path.abspath(".")))
+            self.output.info("cwd: {}".format(os.path.abspath(".")))
             self.output.info("Package folder: {}".format(self.package_folder))
             self.output.error("Globbing: {}".format(glob_pattern))
             raise "Didn't find the libraries!"
@@ -96,11 +100,9 @@ class OpenstudiorubyConan(ConanFile):
         libdirs.sort(key=lambda p: len(os.path.normpath(p).split(os.sep)))
         self.cpp_info.libdirs = libdirs
 
-        self.output.info("cpp_info.libs = {}".format(self.cpp_info.libs))
-
-        # include/ruby-2.5.0/x64-mswin64_140'
-        # 'include/ruby-2.5.0/x86_64-linux',
-        # 'include/ruby-2.5.0/x86_64-darwin17'
-
         self.cpp_info.includedirs = ['include', 'include/ruby-2.5.0']
         self.cpp_info.includedirs.append(self.find_config_header())
+
+        self.output.info("cpp_info.libs = {}".format(self.cpp_info.libs))
+        self.output.info("cpp_info.includedirs = "
+                         "{}".format(self.cpp_info.includedirs))

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,3 +1,5 @@
+import os
+import glob as gb
 from conans import ConanFile, CMake, tools
 
 
@@ -36,16 +38,145 @@ class OpenstudiorubyConan(ConanFile):
     def package(self):
         self.copy("*", src="Ruby-prefix/src/Ruby-install", keep_path=True)
 
+    def find_config_header(self):
+        """
+        Locate the ruby/config.h which will be in different folders depending
+        on the platform
+        """
+        found = gb.glob("**/ruby/config.h", recursive=True)
+        if len(found) != 1:
+            raise "Didn't find one and one only ruby/config.h"
+
+        p = found[0]
+        abspath = os.path.abspath(os.path.join(p, os.pardir, os.pardir))
+        relpath = os.path.relpath(abspath, ".")
+        print("Found config.h in {}".format(relpath))
+        return relpath
+
     def package_info(self):
-        # TODO: This can certainly be done better with file globbing or something
+        # TODO: This can certainly be done better with file globbing
+        # or something
 
         if self.settings.os == "Windows":
-            self.cpp_info.libs = ['x64-vcruntime140-ruby250-static.lib', "at_exit-x64-mswin64_140.lib", "bigdecimal.lib", "bignum-x64-mswin64_140.lib", "bubblebabble.lib", "bug_3571-x64-mswin64_140.lib", "bug_5832-x64-mswin64_140.lib", "bug_reporter-x64-mswin64_140.lib", "call_without_gvl-x64-mswin64_140.lib", "class-x64-mswin64_140.lib", "compat-x64-mswin64_140.lib", "console.lib", "console-x64-mswin64_140.lib", "continuation.lib", "coverage.lib", "cparse.lib", "date_core.lib", "debug-x64-mswin64_140.lib", "digest.lib", "dlntest.lib", "dln-x64-mswin64_140.lib", "dot.dot-x64-mswin64_140.lib", "empty-x64-mswin64_140.lib", "escape.lib", "etc.lib", "exception-x64-mswin64_140.lib", "fcntl.lib", "fd_setsize-x64-mswin64_140.lib", "fiber.lib", "fiddle.lib", "file-x64-mswin64_140.lib", "float-x64-mswin64_140.lib", "foreach-x64-mswin64_140.lib", "funcall-x64-mswin64_140.lib", "generator.lib", "hash-x64-mswin64_140.lib", "integer-x64-mswin64_140.lib", "internal_ivar-x64-mswin64_140.lib", "iseq_load-x64-mswin64_140.lib", "iter-x64-mswin64_140.lib", "md5.lib", "memory_status-x64-mswin64_140.lib", "method-x64-mswin64_140.lib", "nkf.lib", "nonblock.lib", "notimplement-x64-mswin64_140.lib", "num2int-x64-mswin64_140.lib", "numhash-x64-mswin64_140.lib", "objspace.lib", "openssl.lib", "parser.lib", "path_to_class-x64-mswin64_140.lib", "pathname.lib", "postponed_job-x64-mswin64_140.lib", "printf-x64-mswin64_140.lib", "proc-x64-mswin64_140.lib", "protect-x64-mswin64_140.lib", "psych.lib", "rational-x64-mswin64_140.lib", "rb_fatal-x64-mswin64_140.lib", "recursion-x64-mswin64_140.lib", "regexp-x64-mswin64_140.lib", "resize-x64-mswin64_140.lib", "resolv.lib", "ripper.lib", "rmd160.lib", "scan_args-x64-mswin64_140.lib", "sdbm.lib", "sha1.lib", "sha2.lib", "sizeof.lib", "socket.lib", "stringio.lib", "string-x64-mswin64_140.lib", "strscan.lib", "struct-x64-mswin64_140.lib", "symbol-x64-mswin64_140.lib", "thread_fd_close-x64-mswin64_140.lib", "time-x64-mswin64_140.lib", "tracepoint-x64-mswin64_140.lib", "typeddata-x64-mswin64_140.lib", "update-x64-mswin64_140.lib", "usr-x64-mswin64_140.lib", "wait.lib", "wait_for_single_fd-x64-mswin64_140.lib", "zlib.lib", "libtrans.lib", "libenc.lib"]
+            # self.cpp_info.libs = ['x64-vcruntime140-ruby250-static.lib',
+            #                       "at_exit-x64-mswin64_140.lib",
+            #                       "bigdecimal.lib",
+            #                       "bignum-x64-mswin64_140.lib",
+            #                       "bubblebabble.lib",
+            #                       "bug_3571-x64-mswin64_140.lib",
+            #                       "bug_5832-x64-mswin64_140.lib",
+            #                       "bug_reporter-x64-mswin64_140.lib",
+            #                       "call_without_gvl-x64-mswin64_140.lib",
+            #                       "class-x64-mswin64_140.lib",
+            #                       "compat-x64-mswin64_140.lib",
+            #                       "console.lib",
+            #                       "console-x64-mswin64_140.lib",
+            #                       "continuation.lib",
+            #                       "coverage.lib",
+            #                       "cparse.lib",
+            #                       "date_core.lib",
+            #                       "debug-x64-mswin64_140.lib",
+            #                       "digest.lib",
+            #                       "dlntest.lib",
+            #                       "dln-x64-mswin64_140.lib",
+            #                       "dot.dot-x64-mswin64_140.lib",
+            #                       "empty-x64-mswin64_140.lib",
+            #                       "escape.lib",
+            #                       "etc.lib",
+            #                       "exception-x64-mswin64_140.lib",
+            #                       "fcntl.lib",
+            #                       "fd_setsize-x64-mswin64_140.lib",
+            #                       "fiber.lib",
+            #                       "fiddle.lib",
+            #                       "file-x64-mswin64_140.lib",
+            #                       "float-x64-mswin64_140.lib",
+            #                       "foreach-x64-mswin64_140.lib",
+            #                       "funcall-x64-mswin64_140.lib",
+            #                       "generator.lib",
+            #                       "hash-x64-mswin64_140.lib",
+            #                       "integer-x64-mswin64_140.lib",
+            #                       "internal_ivar-x64-mswin64_140.lib",
+            #                       "iseq_load-x64-mswin64_140.lib",
+            #                       "iter-x64-mswin64_140.lib",
+            #                       "md5.lib",
+            #                       "memory_status-x64-mswin64_140.lib",
+            #                       "method-x64-mswin64_140.lib",
+            #                       "nkf.lib",
+            #                       "nonblock.lib",
+            #                       "notimplement-x64-mswin64_140.lib",
+            #                       "num2int-x64-mswin64_140.lib",
+            #                       "numhash-x64-mswin64_140.lib",
+            #                       "objspace.lib",
+            #                       "openssl.lib",
+            #                       "parser.lib",
+            #                       "path_to_class-x64-mswin64_140.lib",
+            #                       "pathname.lib",
+            #                       "postponed_job-x64-mswin64_140.lib",
+            #                       "printf-x64-mswin64_140.lib",
+            #                       "proc-x64-mswin64_140.lib",
+            #                       "protect-x64-mswin64_140.lib",
+            #                       "psych.lib",
+            #                       "rational-x64-mswin64_140.lib",
+            #                       "rb_fatal-x64-mswin64_140.lib",
+            #                       "recursion-x64-mswin64_140.lib",
+            #                       "regexp-x64-mswin64_140.lib",
+            #                       "resize-x64-mswin64_140.lib",
+            #                       "resolv.lib",
+            #                       "ripper.lib",
+            #                       "rmd160.lib",
+            #                       "scan_args-x64-mswin64_140.lib",
+            #                       "sdbm.lib",
+            #                       "sha1.lib",
+            #                       "sha2.lib",
+            #                       "sizeof.lib",
+            #                       "socket.lib",
+            #                       "stringio.lib",
+            #                       "string-x64-mswin64_140.lib",
+            #                       "strscan.lib",
+            #                       "struct-x64-mswin64_140.lib",
+            #                       "symbol-x64-mswin64_140.lib",
+            #                       "thread_fd_close-x64-mswin64_140.lib",
+            #                       "time-x64-mswin64_140.lib",
+            #                       "tracepoint-x64-mswin64_140.lib",
+            #                       "typeddata-x64-mswin64_140.lib",
+            #                       "update-x64-mswin64_140.lib",
+            #                       "usr-x64-mswin64_140.lib",
+            #                       "wait.lib",
+            #                       "wait_for_single_fd-x64-mswin64_140.lib",
+            #                       "zlib.lib",
+            #                       "libtrans.lib",
+            #                       "libenc.lib"]
 
-            self.cpp_info.libdirs = ['lib', 'lib/ext', 'lib/enc']
-            self.cpp_info.includedirs = ['include', 'include/ruby-2.5.0', 'include/ruby-2.5.0/x64-mswin64_140']
+            libext = "lib"
+
         else:
-            self.cpp_info.libs = ['libruby-static.a', "pathname.a", "objspace.a", "readline.a", "zlib.a", "sizeof.a", "strscan.a", "parser.a", "fiber.a", "cparse.a", "wait.a", "fcntl.a", "coverage.a", "stringio.a", "generator.a", "nonblock.a", "psych.a", "socket.a", "pty.a", "etc.a", "dbm.a", "fiddle.a", 'sha2.a', "syslog.a", "sdbm.a", "digest.a", "bigdecimal.a", "console.a", "bubblebabble.a", "ripper.a", 'date_core.a', "nkf.a", "gdbm.a", 'rmd160.a', "continuation.a", "openssl.a", 'sha1.a', 'md5.a', "escape.a", "libtrans.a", "libenc.a"]
 
-            self.cpp_info.libdirs = ['lib', 'lib/ext', 'lib/enc']
-            self.cpp_info.includedirs = ['include', 'include/ruby-2.5.0', 'include/ruby-2.5.0/x86_64-linux']
+            # self.cpp_info.libs = ['libruby-static.a', "pathname.a",
+            #                       "objspace.a", "readline.a", "zlib.a",
+            #                       "sizeof.a", "strscan.a", "parser.a",
+            #                       "fiber.a", "cparse.a", "wait.a", "fcntl.a",
+            #                       "coverage.a", "stringio.a", "generator.a",
+            #                       "nonblock.a", "psych.a", "socket.a",
+            #                       "pty.a", "etc.a", "dbm.a", "fiddle.a",
+            #                       'sha2.a', "syslog.a", "sdbm.a", "digest.a",
+            #                       "bigdecimal.a", "console.a",
+            #                       "bubblebabble.a", "ripper.a", 'date_core.a',
+            #                       "nkf.a", "gdbm.a", 'rmd160.a',
+            #                       "continuation.a", "openssl.a", 'sha1.a',
+            #                       'md5.a', "escape.a", "libtrans.a",
+            #                       "libenc.a"]
+
+            libext = ".a"
+
+
+        self.cpp_info.libs = libs = [os.path.basename(x) for x
+                                     in gb.glob("**/*.{}".format(libext),
+                                                recursive=True)]
+
+        # include/ruby-2.5.0/x64-mswin64_140'
+        # 'include/ruby-2.5.0/x86_64-linux',
+        # 'include/ruby-2.5.0/x86_64-darwin17'
+        self.cpp_info.libdirs = ['lib', 'lib/ext', 'lib/enc']
+        self.cpp_info.includedirs = ['include', 'include/ruby-2.5.0']
+        self.cpp_info.includedirs.append(self.find_config_header())
+

--- a/test_openssl_version.rb
+++ b/test_openssl_version.rb
@@ -1,0 +1,16 @@
+require 'openssl'
+
+# Expects one argument: the OpenSSL version, eg "1.1.0g"
+expected_v = ARGV[0]
+
+if expected_v.nil? or (not expected_v.match(/\d+\.\d+\.\d+[a-z]/))
+  raise "Wrong expected version '#{expected_v}'"
+end
+
+v = OpenSSL::OPENSSL_VERSION[/\d+\.\d+\.\d+[a-z]/]
+
+if v == expected_v
+  puts "OK OpenSSL Version match: '#{v}'"
+else
+  raise "Version Mismatch: expected '#{expected_v}', got '#{v}'"
+end


### PR DESCRIPTION
I made the conanfile.py rely on globbing instead of harcoding include dirs and library names. I was getting an error on mac because it didn't find the `ruby/config.h`, as the include folder is platform dependent and was only set for linux and windows.

I also updated conan-cmake to v0.14 to match the OpenStudio CMakeLists.txt.

I uploaded it to my bintray `openstudio_ruby/2.5.5@jmarrec/testing` but since it has the same version as the one before, **you will need to manually remove any prior openstudio_ruby or it won't download the new version**