### PR TITLE
To be merged in once NREL's travis/appveyor are set up

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ A [conan](https://conan.io/) package to build ruby for [OpenStudio](https://gith
 
 | Bintray | Windows | Linux & macOS |
 |:--------:|:---------:|:-----------------:|
-|[![Download](https://api.bintray.com/packages/commercialbuilding/nrel/openstudio_ruby%3Anrel/images/download.svg)](https://bintray.com/commercialbuilding/nrel/openstudio_ruby%3Anrel/_latestVersion)|[![Build status](https://ci.appveyor.com/api/projects/status/github/jmarrec/conan-openstudio-ruby?svg=true)](https://ci.appveyor.com/project/jmarrec/conan-openstudio-ruby)|[![Build Status](https://travis-ci.org/jmarrec/conan-openstudio-ruby.svg?branch=master)](https://travis-ci.org/jmarrec/conan-openstudio-ruby)|
+|[![Download](https://api.bintray.com/packages/commercialbuilding/nrel/openstudio_ruby%3Anrel/images/download.svg)](https://bintray.com/commercialbuilding/nrel/openstudio_ruby%3Anrel/_latestVersion)|[![Build status](https://ci.appveyor.com/api/projects/status/github/ci-commercialbuildings/conan-openstudio-ruby?svg=true)](https://ci.appveyor.com/project/ci-commercialbuildings/conan-openstudio-ruby)|[![Build Status](https://travis-ci.org/nrel/conan-openstudio-ruby.svg?branch=master)](https://travis-ci.org/nrel/conan-openstudio-ruby)|
 
 CI is done by Travis for Linux&Mac, and AppVeyor for Windows. To ignore specific commits, please add tags in your commit message such as `[skip ci]` (skip all), `[skip travis]` or `[skip appveyor]`.
 
-## Uploading to bintray (unecessary due to CI)
+## Uploading to Bintray (unnecessary due to CI)
 
 Full instructions available at [Conan Docs](https://docs.conan.io/en/latest/uploading_packages/bintray/uploading_bintray.html).
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,11 +9,11 @@ from conans.errors import ConanException
 class OpenstudiorubyConan(ConanFile):
     name = "openstudio_ruby"
     version = "2.5.5"
-    license = "<Put the package license here>"
-    author = "<Put your name here> <And your email here>"
-    url = "<Package recipe repository url here, for issues about the package>"
-    description = "<Description of Openstudioruby here>"
-    topics = ("<Put some tag here>", "<here>", "<and here>")
+    license = "<Put the package license here>" # TODO
+    author = "NREL <openstudio@nrel.gov>"
+    url = "https://github.com/NREL/conan-openstudio-ruby"
+    description = "Static ruby for use in OpenStudio's Command Line Interface"
+    topics = ("ruby", "openstudio")
     settings = "os", "compiler", "build_type", "arch"
     exports_sources = "*"
     generators = "cmake"
@@ -47,7 +47,6 @@ class OpenstudiorubyConan(ConanFile):
             self.output.warn(
                 "Conan GMP isn't supported on MSVC")
             self.options.with_gmp = False
-
 
     def requirements(self):
         """

--- a/conanfile.py
+++ b/conanfile.py
@@ -66,7 +66,7 @@ class OpenstudiorubyConan(ConanFile):
             # self.options["libffi"].fPIC = True
 
         if self.options.with_gdbm:
-            self.requires("gdbm/1.18.1@jmarrec/testing")
+            self.requires("gdbm/1.18.1@bincrafters/stable")
             self.options["gdbm"].shared = False
             # self.options["gdbm"].fPIC = True
             self.options["gdbm"].libgdbm_compat = True


### PR DESCRIPTION
Once Travis and Appveyor are set up like mentioned on https://github.com/NREL/conan-openstudio-ruby/pull/6#issuecomment-510927907, close #6 and merge this one. This will generate new openstudio_ruby/2.5.5@nrel/stable packages that we can use for openstudio.

Then hit merge https://github.com/NREL/OpenStudio/pull/3596