### PR TITLE
Fix #10  - Change CI settings to rely on Conan package tools add_common_builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,20 +10,14 @@ osx: &osx
    language: generic
 matrix:
    include:
-      # 32 bits builds
-      #- <<: *linux
-      #  env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7 CONAN_ARCHS=x86
-      #- <<: *linux
-      #  env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8 CONAN_ARCHS=x86
-      #- <<: *linux
-      #  env: CONAN_GCC_VERSIONS=9 CONAN_DOCKER_IMAGE=conanio/gcc9 CONAN_ARCHS=x86
-      # 64-bit builds on GCC 7/8/9
+
+      # 64-bit builds on GCC 7/8/9. GCC 7 is the one listed on the wiki, so build Debug and Release for this one. Only release for GCC 8 and GCC 9
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7 CONAN_ARCHS=x86_64
+        env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release,Debug
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8 CONAN_ARCHS=x86_64
+        env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=9 CONAN_DOCKER_IMAGE=conanio/gcc9 CONAN_ARCHS=x86_64
+        env: CONAN_GCC_VERSIONS=9 CONAN_DOCKER_IMAGE=conanio/gcc9 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
 
       #- <<: *osx
         #osx_image: xcode8.3
@@ -36,7 +30,7 @@ matrix:
         #env: CONAN_APPLE_CLANG_VERSIONS=9.1
       - <<: *osx
         osx_image: xcode10.1
-        env: CONAN_APPLE_CLANG_VERSIONS=10.0
+        env: CONAN_APPLE_CLANG_VERSIONS=10.0 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release,Debug
 
 install:
   - chmod +x .ci/install.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,19 +2,19 @@ build: false
 
 environment:
     PYTHON_HOME: "C:\\Python37"
+    CONAN_VISUAL_RUNTIMES: MD,MDd   # Ignoring MT and MTd
+    CONAN_ARCHS: x86_64   # Don't want to build for x86
 
     matrix:
 
         # 2017 is the target MSVC for now, so build Release and Debug, x64 only
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
-          CONAN_ARCHS: x86_64   # or: x86_64,x86
           CONAN_BUILD_TYPES: Release,Debug
 
         # To check if it works with MSVC 2019, we also produce a Release build on 2019, x64 only
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
           CONAN_VISUAL_VERSIONS: 16
-          CONAN_ARCHS: x86_64
           CONAN_BUILD_TYPES: Release
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,63 +5,17 @@ environment:
 
     matrix:
 
+        # 2017 is the target MSVC for now, so build Release and Debug, x64 only
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
-          CONAN_ARCHS: x86_64
-          CONAN_BUILD_TYPES: Release
+          CONAN_ARCHS: x86_64   # or: x86_64,x86
+          CONAN_BUILD_TYPES: Release,Debug
 
+        # To check if it works with MSVC 2019, we also produce a Release build on 2019, x64 only
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
           CONAN_VISUAL_VERSIONS: 16
           CONAN_ARCHS: x86_64
           CONAN_BUILD_TYPES: Release
-
-#        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-#          CONAN_VISUAL_VERSIONS: 15
-#          CONAN_ARCHS: x86_64
-#          CONAN_BUILD_TYPES: Debug
-#
-#        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-#          CONAN_VISUAL_VERSIONS: 16
-#          CONAN_ARCHS: x86_64
-#          CONAN_BUILD_TYPES: Debug
-#
-#
-#        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-#          CONAN_VISUAL_VERSIONS: 14
-#          CONAN_ARCHS: x86_64
-#          CONAN_BUILD_TYPES: Release
-#        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-#          CONAN_VISUAL_VERSIONS: 14
-#          CONAN_ARCHS: x86_64
-#          CONAN_BUILD_TYPES: Debug
-#
-#
-#        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-#          CONAN_VISUAL_VERSIONS: 14
-#          CONAN_ARCHS: x86
-#          CONAN_BUILD_TYPES: Release
-#        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-#          CONAN_VISUAL_VERSIONS: 14
-#          CONAN_ARCHS: x86
-#          CONAN_BUILD_TYPES: Debug
-#
-#        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-#          CONAN_VISUAL_VERSIONS: 15
-#          CONAN_ARCHS: x86
-#          CONAN_BUILD_TYPES: Release
-#        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-#          CONAN_VISUAL_VERSIONS: 15
-#          CONAN_ARCHS: x86
-#          CONAN_BUILD_TYPES: Debug
-#
-#        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-#          CONAN_VISUAL_VERSIONS: 16
-#          CONAN_ARCHS: x86
-#          CONAN_BUILD_TYPES: Debug
-#        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-#          CONAN_VISUAL_VERSIONS: 16
-#          CONAN_ARCHS: x86
-#          CONAN_BUILD_TYPES: Release
 
 install:
   - set PATH=%PYTHON_HOME%;%PYTHON_HOME%/Scripts/;%PATH%

--- a/build.py
+++ b/build.py
@@ -1,20 +1,18 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import os
-from bincrafters import (build_template_default,
-                         build_template_installer,
-                         build_shared)
+from bincrafters import build_template_default
 
 if __name__ == "__main__":
 
-    if "ARCH" in os.environ:
-        arch = os.environ["ARCH"]
-        builder = build_template_installer.get_builder(build_policy="outdated")
-        builder.add(settings={"os": build_shared.get_os(),
-                              "arch_build": arch,
-                              "arch": arch})
-    else:
-        builder = build_template_default.get_builder(build_policy="outdated")
-
-builder.run()
+    # This will add common builds.
+    # We are customizing what these are by using environment variables.
+    # Because we pass:
+    # * CONAN_ARCHS=x86_64, it will only produce the x64
+    # * CONAN_APPLE_CLANG_VERSIONS/CONAN_GCC_VERSIONS/CONAN_VISUAL_VERSIONS,
+    #   it will only use the specific one that's passed
+    # * CONAN_BUILD_TYPES, it will limit itself to the ones we asked
+    # cf: https://github.com/conan-io/conan-package-tools
+    # Specifically in ./cpt/builds_generator.py
+    builder = build_template_default.get_builder(build_policy="outdated")
+    builder.run()


### PR DESCRIPTION
Fix #10 - Change CI settings to rely on Conan-package-tools' add_common_builds. Cf notes in build.py.

MSVC 2017 is our windows target compiler, so for this one produce Release + Debug. Same idea for GCC 7. 

**The idea is that we'll produce these builds:**

| Platform | Compiler   | Release | Debug | Verified? |
|----------|------------|---------|-------|-----------|
| Windows  | MSVC 2017  | X       | X     |  [Yes](https://ci.appveyor.com/project/ci-commercialbuildings/conan-openstudio-ruby/builds/26372866/job/tj17r6atgptqa5da?fullLog=true#L202)      |
| Windows  | MSVC 2019  | X       |       |   [Yes](https://ci.appveyor.com/project/ci-commercialbuildings/conan-openstudio-ruby/builds/26372866/job/4vhw773b8sx4l2xi#L203)         |
| Linux    | GCC 7      | X       | X     |      [Yes](https://travis-ci.org/NREL/conan-openstudio-ruby/jobs/565988903#L401)     |
| Linux    | GCC 8      | X       |       |      [Yes](https://travis-ci.org/NREL/conan-openstudio-ruby/jobs/565988906#L402)     |
| Linux    | GCC 9      | X       |       |     [Yes](https://travis-ci.org/NREL/conan-openstudio-ruby/jobs/565988908#L402) |
| Mac      | Xcode 10.1 | X       | X     |       [Yes](https://travis-ci.org/NREL/conan-openstudio-ruby/jobs/565988909#L3365)    |


**All builds are done only for x86_64, not x86**

**I'm going to let CI build this PR and will check that the common builds are what I expect**
