### PR TITLE
Fix DBM issues and specifically check for ext libs in build script to output messages if not work

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -25,9 +25,9 @@ if [[ $machine == Darwin ]]; then
   pyenv virtualenv 3.7.1 conan
   pyenv rehash
   pyenv activate conan
-elif [[ $machine == Linux ]]; then
-  # You're not root by default in conanio docker images
-  sudo apt install libgdbm-dev
+#elif [[ $machine == Linux ]]; then
+#  # You're not root by default in conanio docker images
+#  sudo apt install libgdbm-dev
 fi
 
 pip install conan --upgrade

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -26,7 +26,8 @@ if [[ $machine == Darwin ]]; then
   pyenv rehash
   pyenv activate conan
 elif [[ $machine == Linux ]]; then
-  apt install libgdbm-dev
+  # You're not root by default in conanio docker images
+  sudo apt install libgdbm-dev
 fi
 
 pip install conan --upgrade

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -2,22 +2,31 @@
 
 set -ex
 
-if [[ "$(uname -s)" == 'Darwin' ]]; then
-    brew update || brew update
-    brew outdated pyenv || brew upgrade pyenv
-    brew install pyenv-virtualenv
-    brew install cmake || true
-
-    if which pyenv > /dev/null; then
-        eval "$(pyenv init -)"
-    fi
-
-    pyenv install 3.7.1
-    pyenv virtualenv 3.7.1 conan
-    pyenv rehash
-    pyenv activate conan
+unameOut="$(uname -s)"
+case "${unameOut}" in
+  Linux*)     machine=Linux;;
+  Darwin*)    machine=Darwin;;
+  CYGWIN*|MINGW*|MSYS*)    machine=Windows;;
+  *)          machine="UNKNOWN:${unameOut}"
+esac
 
 
+if [[ $machine == Darwin ]]; then
+  brew update || brew update
+  brew outdated pyenv || brew upgrade pyenv
+  brew install pyenv-virtualenv
+  brew install cmake || true
+
+  if which pyenv > /dev/null; then
+    eval "$(pyenv init -)"
+  fi
+
+  pyenv install 3.7.1
+  pyenv virtualenv 3.7.1 conan
+  pyenv rehash
+  pyenv activate conan
+elif [[ $machine == Linux ]]; then
+  apt install libgdbm-dev
 fi
 
 pip install conan --upgrade

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,13 +135,14 @@ FindValue(CONAN_LIB_DIRS_GMP)
 # TODO: there might be side effects supplying "with-xxx-dir=''" if not defined. Problem is that generator expressions are evaluated as build time... So need to wrap into another
 # Note JM 2019-06-20: Please mind the space after the true_string arg.
 # Notice that we pass --with-dbm-dir poiting to conan gdbm: that's because we build with gdbm_compat which should provide dbm too
+# We also pass `--with-dbm-type=gdbm_compat` since we use GDBM > 1.8.1 (found this arg in `Ruby/ext/extconf.rb`)
 set(CONF_ARGS
 "$<IF:$<BOOL:${CURRENT_CONAN_ZLIB_ROOT}>,--with-zlib-dir=${CURRENT_CONAN_ZLIB_ROOT} ,>\
 $<IF:$<BOOL:${CURRENT_CONAN_OPENSSL_ROOT}>,--with-openssl-dir=${CURRENT_CONAN_OPENSSL_ROOT} ,>\
 $<IF:$<BOOL:${CURRENT_CONAN_LIBFFI_ROOT}>,--with-libffi-dir=${CURRENT_CONAN_LIBFFI_ROOT} ,>\
 $<IF:$<BOOL:${CURRENT_CONAN_LIBYAML_ROOT}>,--with-libyaml-dir=${CURRENT_CONAN_LIBYAML_ROOT} ,>\
 $<IF:$<BOOL:${CURRENT_CONAN_GDBM_ROOT}>,--with-gdbm-dir=${CURRENT_CONAN_GDBM_ROOT} ,>\
-$<IF:$<BOOL:${CURRENT_CONAN_GDBM_ROOT}>,--with-dbm-dir=${CURRENT_CONAN_GDBM_ROOT} ,>\
+$<IF:$<BOOL:${CURRENT_CONAN_GDBM_ROOT}>,--with-dbm-dir=${CURRENT_CONAN_GDBM_ROOT} --with-dbm-type=gdbm_compat ,>\
 $<IF:$<BOOL:${CURRENT_CONAN_READLINE_ROOT}>,--with-readline-dir=${CURRENT_CONAN_READLINE_ROOT} ,>\
 $<IF:$<BOOL:${CURRENT_CONAN_GMP_ROOT}>,--with-gmp-dir=${CURRENT_CONAN_GMP_ROOT} ,>"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,22 +134,26 @@ FindValue(CONAN_LIB_DIRS_GMP)
 
 # TODO: there might be side effects supplying "with-xxx-dir=''" if not defined. Problem is that generator expressions are evaluated as build time... So need to wrap into another
 # Note JM 2019-06-20: Please mind the space after the true_string arg.
+# Notice that we pass --with-dbm-dir poiting to conan gdbm: that's because we build with gdbm_compat which should provide dbm too
 set(CONF_ARGS
 "$<IF:$<BOOL:${CURRENT_CONAN_ZLIB_ROOT}>,--with-zlib-dir=${CURRENT_CONAN_ZLIB_ROOT} ,>\
 $<IF:$<BOOL:${CURRENT_CONAN_OPENSSL_ROOT}>,--with-openssl-dir=${CURRENT_CONAN_OPENSSL_ROOT} ,>\
 $<IF:$<BOOL:${CURRENT_CONAN_LIBFFI_ROOT}>,--with-libffi-dir=${CURRENT_CONAN_LIBFFI_ROOT} ,>\
 $<IF:$<BOOL:${CURRENT_CONAN_LIBYAML_ROOT}>,--with-libyaml-dir=${CURRENT_CONAN_LIBYAML_ROOT} ,>\
 $<IF:$<BOOL:${CURRENT_CONAN_GDBM_ROOT}>,--with-gdbm-dir=${CURRENT_CONAN_GDBM_ROOT} ,>\
+$<IF:$<BOOL:${CURRENT_CONAN_GDBM_ROOT}>,--with-dbm-dir=${CURRENT_CONAN_GDBM_ROOT} ,>\
 $<IF:$<BOOL:${CURRENT_CONAN_READLINE_ROOT}>,--with-readline-dir=${CURRENT_CONAN_READLINE_ROOT} ,>\
 $<IF:$<BOOL:${CURRENT_CONAN_GMP_ROOT}>,--with-gmp-dir=${CURRENT_CONAN_GMP_ROOT} ,>"
 )
 
+# TODO: once/if gdbm works on MSVC, check the gdbm_compat.lib name and others
 set(EXTLIBS
 "$<IF:$<BOOL:${CURRENT_CONAN_LIB_DIRS_ZLIB}>,${CURRENT_CONAN_LIB_DIRS_ZLIB}/zlib.lib ,>\
 $<IF:$<BOOL:${CURRENT_CONAN_LIB_DIRS_OPENSSL}>,${CURRENT_CONAN_LIB_DIRS_OPENSSL}/libcrypto.lib ${CURRENT_CONAN_LIB_DIRS_OPENSSL}/libssl.lib ,>\
 $<IF:$<BOOL:${CURRENT_CONAN_LIB_DIRS_LIBFFI}>,${CURRENT_CONAN_LIB_DIRS_LIBFFI}/libffi.lib ,>\
 $<IF:$<BOOL:${CURRENT_CONAN_LIB_DIRS_LIBYAML}>,${CURRENT_CONAN_LIB_DIRS_LIBYAML}/yaml.lib ,>\
 $<IF:$<BOOL:${CURRENT_CONAN_LIB_DIRS_GDBM}>,${CURRENT_CONAN_LIB_DIRS_GDBM}/gdbm.lib ,>\
+$<IF:$<BOOL:${CURRENT_CONAN_LIB_DIRS_GDBM}>,${CURRENT_CONAN_LIB_DIRS_GDBM}/gdbm_compat.lib ,>\
 $<IF:$<BOOL:${CURRENT_CONAN_LIB_DIRS_READLINE}>,${CURRENT_CONAN_LIB_DIRS_READLINE}/readline.lib ,>\
 $<IF:$<BOOL:${CURRENT_CONAN_LIB_DIRS_GMP}>,${CURRENT_CONAN_LIB_DIRS_GMP}/libgmp.lib ,> "
 )

--- a/conanfile.py
+++ b/conanfile.py
@@ -321,9 +321,10 @@ class OpenstudiorubyConan(ConanFile):
                               'usr-x64-mswin64_140.lib',
                               'wait_for_single_fd-x64-mswin64_140.lib']
 
+        n_libs = len(libs)
         n_expected_libs = len(expected_libs)
-        if (len(libs) == len(n_expected_libs)):
-            self.output.success("Found {} libs".format(len(libs)))
+        if (n_libs == n_expected_libs):
+            self.output.success("Found {} libs".format(n_libs))
 
         else:
             missing_libs = set(expected_libs) - set(libs)
@@ -337,7 +338,7 @@ class OpenstudiorubyConan(ConanFile):
                                   "{}".format(len(extra_libs), extra_libs))
 
             self.output.error("Found {} libs, expected {} "
-                              "libs".format(len(libs), len(n_expected_libs)))
+                              "libs".format(n_libs, n_expected_libs))
 
         # self.cpp_info.libdirs = ['lib', 'lib/ext', 'lib/enc']
         # Equivalent automatic detection


### PR DESCRIPTION
Fix #13: Conan GDBM is specifically built with `gdbm_compat` so it can provide `dbm`, but we also need to pass `--with-dbm-dir=${CURRENT_CONAN_GDBM_ROOT}` to the ruby `configure` command so that it can find the `gdbm_compat` library, otherwise it looks in system libs and won't find thel.

While at it, I guess it's better to also pass `--with-dbm-type=gdbm_compat` to avoid any problems. looking at build logs on travis, if you don't pass this, it'll still correctly infer that it's gdbm_compat though, but better be safe/explicit I think (cf https://travis-ci.org/NREL/conan-openstudio-ruby/jobs/571236788#L1989). I'm open to reverting the last commit though, **Thoughts anyone?**

Extract from the `Ruby/ext/dbm/extconfig.rb`:

```
# configure option:
#   --with-dbm-type=COMMA-SEPARATED-NDBM-TYPES
#
# ndbm type:
#   libc        ndbm compatible library in libc.
#   db          Berkeley DB (libdb)
#   db2         Berkeley DB (libdb2)
#   db1         Berkeley DB (libdb1)
#   db5         Berkeley DB (libdb5)
#   db4         Berkeley DB (libdb4)
#   db3         Berkeley DB (libdb3)
#   gdbm_compat GDBM since 1.8.1 (libgdbm_compat)
#   gdbm        GDBM until 1.8.0 (libgdbm)
#   qdbm        QDBM (libqdbm)
#   ndbm        Some legacy OS may have libndbm.
```

**Our conan gdbm is 1.18.1, so >= 1.8.1**

----

**Other changes**: I initially had written stuff to glob the libraries in the build fodler for the `package()` method, which I'm still doing. But I added the explicit **expected** libraries depending on platform and settings passed, so that we can at least output (error) messages to the console if we don't get what we expected. It might be a bit annoying to maintain if we add new compilers or change ruby versions, but we can revisit that at that point.