### PR TITLE
If we build FFI, package it.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,7 +284,7 @@ else()
     PATCH_COMMAND ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/Ruby.patch && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/Ruby.win.patch  # && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/Ruby.nodynamic.patch
     CONFIGURE_COMMAND ""
     BUILD_COMMAND cmd /C "${CMAKE_BINARY_DIR}/build_ruby_$<CONFIG>.bat"
-    INSTALL_COMMAND ""
+    INSTALL_COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib/libffi.lib" "${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/lib/"
     # Run a ruby script to ensure we linked against the right OpenSSL
     TEST_COMMAND cmd /C "${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/bin/ruby ${CMAKE_SOURCE_DIR}/test_openssl_version.rb ${OPENSSL_VERSION}"
   )

--- a/conanfile.py
+++ b/conanfile.py
@@ -315,6 +315,11 @@ class OpenstudiorubyConan(ConanFile):
                               'usr-x64-mswin64_140.lib',
                               'wait_for_single_fd-x64-mswin64_140.lib']
 
+
+            self.output.warn(
+                "Since we are building a custom libffi, we are packaging it, as it's required for linking our ruby")
+            expected_libs += ['libffi.lib']
+
         n_libs = len(libs)
         n_expected_libs = len(expected_libs)
         if (n_libs == n_expected_libs):


### PR DESCRIPTION
 * Goal: make Conan packages complete
 * Problem:
    * currently this builds FFI on Windows because conan FFI
      doesn't work with Ruby
    * OpenStudio has to provide its own FFI which might not have the
      same build settings
    * this overly complicates the build story for OpenStudio
 * Solution: If we need to build our own FFI, package the .lib file and
   set it up with the conan dependencies

This simplifies the OpenStudio build story, while keeping all the builds
consistent.