### PR TITLE
Update notes on YAML

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -42,9 +42,9 @@ class OpenstudiorubyConan(ConanFile):
                 "Conan LIBFFI will not allow linking right now with MSVC, "
                 "so temporarilly built it from CMakeLists instead")
             self.options.with_libffi = False
-            self.output.warn(
+            self.output.info(
                 "Conan LibYAML will not link properly right now with MSVC, "
-                "so temporarilly disable it")
+                "so using built-in Psych provided libYAML")
             self.options.with_libyaml = False
             self.output.warn(
                 "Conan GMP isn't supported on MSVC")


### PR DESCRIPTION
 - YAML is working fine currently on Windows/MSVC
 - Psych (the libYaml wrapper) provides its own libYAML
 - By not providing our own, Ruby reverts to its built in version
 - The ruby provided version reports at 0.2.1 vs current rev of 0.2.2

This leaves:

 - readline
 - gdbm
 - dbm

Modules as not supported on MSVC