### PR TITLE
Test package env shebangs

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -317,9 +317,9 @@ class OpenstudiorubyConan(ConanFile):
                               'usr-x64-mswin64_140.lib',
                               'wait_for_single_fd-x64-mswin64_140.lib']
 
-
             self.output.warn(
-                "Since we are building a custom libffi, we are packaging it, as it's required for linking our ruby")
+                "Since we are building a custom libffi, we are packaging it, "
+                "as it's required for linking our ruby")
             expected_libs += ['libffi.lib']
 
         n_libs = len(libs)
@@ -355,3 +355,24 @@ class OpenstudiorubyConan(ConanFile):
         self.output.info("cpp_info.libs = {}".format(self.cpp_info.libs))
         self.output.info("cpp_info.includedirs = "
                          "{}".format(self.cpp_info.includedirs))
+
+        # PATH / ENV stuff
+        bindir = os.path.join(self.package_folder, "bin")
+        self.output.info('Appending PATH environment variable: '
+                         '{}'.format(bindir)
+        self.env_info.PATH.append(bindir)
+        self.env_info.RUBY_EXEC_PREFIX = self.package_folder
+        self.env_info.RUBY_BINDIR = bindir
+        self.env_info.RUBY_LIBDIR = os.path.join(self.package_folder, "lib")
+
+
+        # Rewrite shebangs
+        bin_scripts = ['gem', 'ri', 'irb', 'rdoc', 'erb', 'rake']
+        for bin_script in bin_scripts:
+            bin_script_p = os.path.join(self.package_folder, 'bin', bin_script)
+            with open(bin_script_p, 'r') as f:
+                lines = f.read().splitlines()
+            lines[0] = "#!{}".format(os.path.join(self.package_folder,
+                                                  'bin/ruby'))
+            with open(bin_script_p, 'w') as f:
+                f.write("\n".join(lines))

--- a/conanfile.py
+++ b/conanfile.py
@@ -359,12 +359,11 @@ class OpenstudiorubyConan(ConanFile):
         # PATH / ENV stuff
         bindir = os.path.join(self.package_folder, "bin")
         self.output.info('Appending PATH environment variable: '
-                         '{}'.format(bindir)
+                         '{}'.format(bindir))
         self.env_info.PATH.append(bindir)
         self.env_info.RUBY_EXEC_PREFIX = self.package_folder
         self.env_info.RUBY_BINDIR = bindir
         self.env_info.RUBY_LIBDIR = os.path.join(self.package_folder, "lib")
-
 
         # Rewrite shebangs
         bin_scripts = ['gem', 'ri', 'irb', 'rdoc', 'erb', 'rake']

--- a/test_package/openstudio_cli.rb
+++ b/test_package/openstudio_cli.rb
@@ -680,9 +680,9 @@ class CLI
   def command_list
     {
         gem_list: [ Proc.new { ::GemList }, {primary: false, working: true}],
-        gem_install: [ Proc.new { ::InstallGem }, {primary: false, working: false}], # DLM: needs Ruby built with FFI
+        gem_install: [ Proc.new { ::InstallGem }, {primary: false, working: true}], # DLM: needs Ruby built with FFI
         execute_ruby_script: [ Proc.new { ::ExecuteRubyScript }, {primary: false, working: true}],
-        interactive_ruby: [ Proc.new { ::InteractiveRubyShell }, {primary: false, working: false}], # DLM: not working
+        interactive_ruby: [ Proc.new { ::InteractiveRubyShell }, {primary: false, working: true}], # DLM: not working
         ruby_version: [ Proc.new { ::RubyVersion }, {primary: false, working: true}],
         list_commands: [ Proc.new { ::ListCommands }, {primary: true, working: true}]
     }


### PR DESCRIPTION
Just pushing something I had started to do in october. Nothing working, just for discussion.

The idea was to try to overwrite the SHEBANGS to get the irb/gem command working:
* When you build a conan package, it is in `build/xxdfjsdlkfksdjlfjlksdjf`
* then it is installed to `package/xxdfjsdlkfksdjlfjlksdjf`, so even on the **same** machine the shebangs get messed uo