### PR TITLE
Patch ruby to support MSVC 2019 and allow win32 build

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -34,3 +34,8 @@ pip install conan --upgrade
 pip install conan_package_tools bincrafters_package_tools
 # Creates the conan data directory
 conan user
+# Create a reproducible config, and enable revisions
+conan config install https://github.com/conan-io/hooks.git -sf hooks -tf hooks
+conan config set hooks.conan-center
+conan config set general.revisions_enabled=True
+conan config set general.parallel_download=8

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -39,3 +39,5 @@ conan config install https://github.com/conan-io/hooks.git -sf hooks -tf hooks
 conan config set hooks.conan-center
 conan config set general.revisions_enabled=True
 conan config set general.parallel_download=8
+# already done in the travis settings
+# conan remote update nrel https://api.bintray.com/conan/commercialbuilding/nrel --insert 0

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -21,11 +21,19 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     echo ""
     echo ""
   done
+
+  echo "======== LISTING THE GDBM LIB FOLDERS ========"
+  find ~/.conan/data/gdbm/1.18.1/_/_/package/ -name 'lib' -type 'd' | xargs -i@ sh -c 'echo @ && ls @'
+
+  echo "======== LISTING THE GDBM INCLUDE FOLDERS ========"
+  find ~/.conan/data/gdbm/1.18.1/_/_/package/ -name 'include' -type 'd' | xargs -i@ sh -c 'echo @ && ls @'
+
+  echo "=========== RUBY CONFIG.LOG ================"
+  find ~/.conan/data/openstudio_ruby/2.5.5/nrel/testing/build -name "mkmf.log"|while read fname; do
+    echo "============== $fname ============"
+    cat $fname
+    echo ""
+    echo ""
+    echo ""
+  done
 fi
-
-
-echo "======== LISTING THE GDBM LIB FOLDERS ========"
-find ~/.conan/data/gdbm/1.18.1/_/_/package/ -name 'lib' -type 'd' | xargs -i@ sh -c 'echo @ && ls @'
-
-echo "======== LISTING THE GDBM INCLUDE FOLDERS ========"
-find ~/.conan/data/gdbm/1.18.1/_/_/package/ -name 'include' -type 'd' | xargs -i@ sh -c 'echo @ && ls @'

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -2,7 +2,7 @@
 
 # -e: exit as soon as one command fails
 # -x: print each command about to be execute with a leading "+"
-set -x
+set -ex
 
 if [[ "$(uname -s)" == 'Darwin' ]]; then
     if which pyenv > /dev/null; then

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-set -ex
+# -e: exit as soon as one command fails
+# -x: print each command about to be execute with a leading "+"
+set -x
 
 if [[ "$(uname -s)" == 'Darwin' ]]; then
     if which pyenv > /dev/null; then

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -13,48 +13,50 @@ fi
 
 python build.py
 
-if [[ "$(uname -s)" == 'Darwin' ]]; then
-  find ~/.conan/data/openstudio_ruby/2.5.5/nrel/testing/build -name "mkmf.log"|while read fname; do
-    echo "============== $fname ============"
-    cat $fname
-    echo ""
-    echo ""
-    echo ""
-  done
+# Debug: how to retrieve logs: remove the "-e" option above, then cat the logs you want:
 
-  echo "======== LISTING THE GDBM LIB FOLDERS ========"
-  find ~/.conan/data/gdbm/1.18.1/_/_/package/ -name 'lib' -type 'd'|while read dirname; do
-    echo $dirname
-    ls $dirname
-    echo ""
-    echo ""
-    echo ""
-  done
+#if [[ "$(uname -s)" == 'Darwin' ]]; then
+  #find ~/.conan/data/openstudio_ruby/2.5.5/nrel/testing/build -name "mkmf.log"|while read fname; do
+    #echo "============== $fname ============"
+    #cat $fname
+    #echo ""
+    #echo ""
+    #echo ""
+  #done
 
-  echo "======== LISTING THE GDBM INCLUDE FOLDERS ========"
-  find ~/.conan/data/gdbm/1.18.1/_/_/package/ -name 'include' -type 'd'|while read dirname; do
-    echo $dirname
-    ls $dirname
-    echo ""
-    echo ""
-    echo ""
-  done
+  #echo "======== LISTING THE GDBM LIB FOLDERS ========"
+  #find ~/.conan/data/gdbm/1.18.1/_/_/package/ -name 'lib' -type 'd'|while read dirname; do
+    #echo $dirname
+    #ls $dirname
+    #echo ""
+    #echo ""
+    #echo ""
+  #done
 
-  echo "=========== RUBY CONFIG.LOG ================"
-  find ~/.conan/data/openstudio_ruby/2.5.5/nrel/testing/build -name "config.log"|while read fname; do
-    echo "============== $fname ============"
-    cat $fname
-    echo ""
-    echo ""
-    echo ""
-  done
+  #echo "======== LISTING THE GDBM INCLUDE FOLDERS ========"
+  #find ~/.conan/data/gdbm/1.18.1/_/_/package/ -name 'include' -type 'd'|while read dirname; do
+    #echo $dirname
+    #ls $dirname
+    #echo ""
+    #echo ""
+    #echo ""
+  #done
 
-  echo "=========== RUBY CONFIG.STATUS ================"
-  find ~/.conan/data/openstudio_ruby/2.5.5/nrel/testing/build -name "config.status"|while read fname; do
-    echo "============== $fname ============"
-    cat $fname
-    echo ""
-    echo ""
-    echo ""
-  done
-fi
+  #echo "=========== RUBY CONFIG.LOG ================"
+  #find ~/.conan/data/openstudio_ruby/2.5.5/nrel/testing/build -name "config.log"|while read fname; do
+    #echo "============== $fname ============"
+    #cat $fname
+    #echo ""
+    #echo ""
+    #echo ""
+  #done
+
+  #echo "=========== RUBY CONFIG.STATUS ================"
+  #find ~/.conan/data/openstudio_ruby/2.5.5/nrel/testing/build -name "config.status"|while read fname; do
+    #echo "============== $fname ============"
+    #cat $fname
+    #echo ""
+    #echo ""
+    #echo ""
+  #done
+#fi

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -22,3 +22,10 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     echo ""
   done
 fi
+
+
+echo "======== LISTING THE GDBM LIB FOLDERS ========"
+find ~/.conan/data/gdbm/1.18.1/_/_/package/ -name 'lib' -type 'd' | xargs -i@ sh -c 'echo @ && ls @'
+
+echo "======== LISTING THE GDBM INCLUDE FOLDERS ========"
+find ~/.conan/data/gdbm/1.18.1/_/_/package/ -name 'include' -type 'd' | xargs -i@ sh -c 'echo @ && ls @'

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -23,10 +23,22 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
   done
 
   echo "======== LISTING THE GDBM LIB FOLDERS ========"
-  find ~/.conan/data/gdbm/1.18.1/_/_/package/ -name 'lib' -type 'd' | xargs -i@ sh -c 'echo @ && ls @'
+  find ~/.conan/data/gdbm/1.18.1/_/_/package/ -name 'lib' -type 'd'|while read dirname; do
+    echo $dirname
+    ls $dirname
+    echo ""
+    echo ""
+    echo ""
+  done
 
   echo "======== LISTING THE GDBM INCLUDE FOLDERS ========"
-  find ~/.conan/data/gdbm/1.18.1/_/_/package/ -name 'include' -type 'd' | xargs -i@ sh -c 'echo @ && ls @'
+  find ~/.conan/data/gdbm/1.18.1/_/_/package/ -name 'include' -type 'd'|while read dirname; do
+    echo $dirname
+    ls $dirname
+    echo ""
+    echo ""
+    echo ""
+  done
 
   echo "=========== RUBY CONFIG.LOG ================"
   find ~/.conan/data/openstudio_ruby/2.5.5/nrel/testing/build -name "mkmf.log"|while read fname; do

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -41,11 +41,21 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
   done
 
   echo "=========== RUBY CONFIG.LOG ================"
-  find ~/.conan/data/openstudio_ruby/2.5.5/nrel/testing/build -name "mkmf.log"|while read fname; do
+  find ~/.conan/data/openstudio_ruby/2.5.5/nrel/testing/build -name "config.log"|while read fname; do
     echo "============== $fname ============"
     cat $fname
     echo ""
     echo ""
     echo ""
   done
+
+  echo "=========== RUBY CONFIG.STATUS ================"
+  find ~/.conan/data/openstudio_ruby/2.5.5/nrel/testing/build -name "config.status"|while read fname; do
+    echo "============== $fname ============"
+    cat $fname
+    echo ""
+    echo ""
+    echo ""
+  done
+
 fi

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -57,5 +57,4 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
     echo ""
     echo ""
   done
-
 fi

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -14,8 +14,7 @@ fi
 python build.py
 
 if [[ "$(uname -s)" == 'Darwin' ]]; then
-  find ~/.conan/data/openstudio_ruby/2.5.5/nrel/testing/build/*/Ruby-prefix/src/Ruby/ext/gdbm -name “mkmf.log”
-  find . -name "*.yml"|while read fname; do
+  find ~/.conan/data/openstudio_ruby/2.5.5/nrel/testing/build/*/Ruby-prefix/src/Ruby/ext/gdbm -name “mkmf.log”|while read fname; do
     echo "============== $fname ============"
     cat $fname
     echo ""

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -14,7 +14,7 @@ fi
 python build.py
 
 if [[ "$(uname -s)" == 'Darwin' ]]; then
-  find ~/.conan/data/openstudio_ruby/2.5.5/nrel/testing/build/*/Ruby-prefix/src/Ruby/ext/gdbm -name “mkmf.log”|while read fname; do
+  find ~/.conan/data/openstudio_ruby/2.5.5/nrel/testing/build -name "mkmf.log"|while read fname; do
     echo "============== $fname ============"
     cat $fname
     echo ""

--- a/.ci/run.sh
+++ b/.ci/run.sh
@@ -10,3 +10,14 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
 fi
 
 python build.py
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+  find ~/.conan/data/openstudio_ruby/2.5.5/nrel/testing/build/*/Ruby-prefix/src/Ruby/ext/gdbm -name “mkmf.log”
+  find . -name "*.yml"|while read fname; do
+    echo "============== $fname ============"
+    cat $fname
+    echo ""
+    echo ""
+    echo ""
+  done
+fi

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+# Autodetect text files
+* text=auto eol=lf
+
+# Unless the name matches the following overriding patterns
+
+# Definitively text files
+*.py text
+*.patch text
+*.bat text
+*.bat.in text
+*.txt text
+*.cmake text
+*.rb text
+*.yml text
+*.xml text
+*.cpp text
+*.hpp text
+*.i text
+*.hxx.in text
+*.cxx.in text
+Gemfile text

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,10 @@ matrix:
         # OSX
       - <<: *osx
         osx_image: xcode10.3
-        env: CONAN_APPLE_CLANG_VERSIONS=10.0 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
+        env: CONAN_APPLE_CLANG_VERSIONS=10.0 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release,Debug
       - <<: *osx
         osx_image: xcode11.4
-        env: CONAN_APPLE_CLANG_VERSIONS=11.0 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
+        env: CONAN_APPLE_CLANG_VERSIONS=11.0 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release,Debug
 
 install:
   - chmod +x .ci/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,17 +13,17 @@ matrix:
       # Note: Passing CONAN_ENV_COMPILER_LIBCXX=libstdc++ (on mac) or CONAN_ENV_COMPILER_LIBCXX=libstdc++11 doesn't work because Conan package tools will override that.
 
       # 64-bit builds on GCC 7/8/9. GCC 7 is the one listed on the wiki, so build Debug and Release for this one. Only release for GCC 8 and GCC 9
-      - <<: *linux
-        env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release,Debug
-      - <<: *linux
-        env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
-      - <<: *linux
-        env: CONAN_GCC_VERSIONS=9 CONAN_DOCKER_IMAGE=conanio/gcc9 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
+      #- <<: *linux
+        #env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release,Debug
+      #- <<: *linux
+        #env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
+      #- <<: *linux
+        #env: CONAN_GCC_VERSIONS=9 CONAN_DOCKER_IMAGE=conanio/gcc9 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
 
-        # OSX
-      - <<: *osx
-        osx_image: xcode10.3
-        env: CONAN_APPLE_CLANG_VERSIONS=10.0 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release,Debug
+        ## OSX
+      #- <<: *osx
+        #osx_image: xcode10.3
+        #env: CONAN_APPLE_CLANG_VERSIONS=10.0 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release,Debug
       - <<: *osx
         osx_image: xcode11.4
         env: CONAN_APPLE_CLANG_VERSIONS=11.0 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release,Debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ matrix:
 
       # 64-bit builds on GCC 7/8/9. GCC 7 is the one listed on the wiki, so build Debug and Release for this one. Only release for GCC 8 and GCC 9
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
-      #- <<: *linux
-        #env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
-      #- <<: *linux
-        #env: CONAN_GCC_VERSIONS=9 CONAN_DOCKER_IMAGE=conanio/gcc9 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
+        env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release,Debug
+      - <<: *linux
+        env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
+      - <<: *linux
+        env: CONAN_GCC_VERSIONS=9 CONAN_DOCKER_IMAGE=conanio/gcc9 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
 
         # OSX
       - <<: *osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,20 +13,20 @@ matrix:
       # Note: Passing CONAN_ENV_COMPILER_LIBCXX=libstdc++ (on mac) or CONAN_ENV_COMPILER_LIBCXX=libstdc++11 doesn't work because Conan package tools will override that.
 
       # 64-bit builds on GCC 7/8/9. GCC 7 is the one listed on the wiki, so build Debug and Release for this one. Only release for GCC 8 and GCC 9
-      #- <<: *linux
-        #env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release,Debug
-      #- <<: *linux
-        #env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
-      #- <<: *linux
-        #env: CONAN_GCC_VERSIONS=9 CONAN_DOCKER_IMAGE=conanio/gcc9 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
+      # - <<: *linux
+      #   env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release,Debug
+      # - <<: *linux
+      #   env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
+      # - <<: *linux
+      #   env: CONAN_GCC_VERSIONS=9 CONAN_DOCKER_IMAGE=conanio/gcc9 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
 
-        ## OSX
-      #- <<: *osx
-        #osx_image: xcode10.3
-        #env: CONAN_APPLE_CLANG_VERSIONS=10.0 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release,Debug
+        # OSX
+      - <<: *osx
+        osx_image: xcode10.3
+        env: CONAN_APPLE_CLANG_VERSIONS=10.0 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
       - <<: *osx
         osx_image: xcode11.4
-        env: CONAN_APPLE_CLANG_VERSIONS=11.0 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release,Debug
+        env: CONAN_APPLE_CLANG_VERSIONS=11.0 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
 
 install:
   - chmod +x .ci/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ matrix:
       # Note: Passing CONAN_ENV_COMPILER_LIBCXX=libstdc++ (on mac) or CONAN_ENV_COMPILER_LIBCXX=libstdc++11 doesn't work because Conan package tools will override that.
 
       # 64-bit builds on GCC 7/8/9. GCC 7 is the one listed on the wiki, so build Debug and Release for this one. Only release for GCC 8 and GCC 9
-      # - <<: *linux
-      #   env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release,Debug
-      # - <<: *linux
-      #   env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
-      # - <<: *linux
-      #   env: CONAN_GCC_VERSIONS=9 CONAN_DOCKER_IMAGE=conanio/gcc9 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
+      - <<: *linux
+        env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release,Debug
+      - <<: *linux
+        env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
+      - <<: *linux
+        env: CONAN_GCC_VERSIONS=9 CONAN_DOCKER_IMAGE=conanio/gcc9 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
 
         # OSX
       - <<: *osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ matrix:
 
       # 64-bit builds on GCC 7/8/9. GCC 7 is the one listed on the wiki, so build Debug and Release for this one. Only release for GCC 8 and GCC 9
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release,Debug
-      - <<: *linux
-        env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
-      - <<: *linux
-        env: CONAN_GCC_VERSIONS=9 CONAN_DOCKER_IMAGE=conanio/gcc9 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
+        env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
+      #- <<: *linux
+        #env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
+      #- <<: *linux
+        #env: CONAN_GCC_VERSIONS=9 CONAN_DOCKER_IMAGE=conanio/gcc9 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release
 
         # OSX
       - <<: *osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
         osx_image: xcode10.3
         env: CONAN_APPLE_CLANG_VERSIONS=10.0 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release,Debug
       - <<: *osx
-        osx_image: xcode11.2
+        osx_image: xcode11.4
         env: CONAN_APPLE_CLANG_VERSIONS=11.0 CONAN_ARCHS=x86_64 CONAN_BUILD_TYPES=Release,Debug
 
 install:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if (INTEGRATED_CONAN)
   include(${CMAKE_BINARY_DIR}/conan.cmake)
   message("RUNNING CONAN")
 
-  conan_check(VERSION 1.24.0 REQUIRED)
+  conan_check(VERSION 1.28.0 REQUIRED)
 
   conan_add_remote(NAME bincrafters
     URL https://api.bintray.com/conan/bincrafters/public-conan)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,7 +266,10 @@ else()
   add_custom_target(GetTools
       DEPENDS ${CMAKE_BINARY_DIR}/tools/bin/sed.exe)
 
-
+  set(FFI_ARCH "x64")
+  if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "4")
+    set(FFI_ARCH "x86")
+  endif()
 
   ## The libFFI provided by Conan gives us something we cannot link to for some reason (TBD)
   ## It's possible we can move to the in-built deps provided by ruby
@@ -274,16 +277,16 @@ else()
     URL_HASH SHA256=bf6813045c0d470aedc3c69f9ec11fe351c2d7360c7d5396dc9a6ddc4830033c
     URL https://github.com/winlibs/libffi/archive/libffi-3.2.1.zip
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND devenv /upgrade ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_x64/libffi-msvc.sln
-      COMMAND msbuild ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_x64/libffi-msvc.sln /p:Configuration=$<CONFIG> /p:DefineConstants="FFI_BUILDING" "/p:Platform=${CMAKE_VS_PLATFORM_NAME}" "/p:WindowsTargetPlatformVersion=${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}"
+    BUILD_COMMAND devenv /upgrade ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_${FFI_ARCH}/libffi-msvc.sln
+      COMMAND msbuild ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_${FFI_ARCH}/libffi-msvc.sln /p:Configuration=$<CONFIG> /p:DefineConstants="FFI_BUILDING" "/p:Platform=${CMAKE_VS_PLATFORM_NAME}" "/p:WindowsTargetPlatformVersion=${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}"
     INSTALL_COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/
       COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/
       COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/include ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/include
       COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/fficonfig.h ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/include/fficonfig.h
-      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/src/x86/ffitarget.h ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/include/ffitarget.h
+      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/src/${FFI_ARCH}/ffitarget.h ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/include/ffitarget.h # THIS one had a x86 before?
       COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib
-      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_x64/x64/$<CONFIG>/libffi.lib ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib/libffi.lib
-      #COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_x64/x64/$<CONFIG>/libffi.pdb ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib/libffi.pdb
+      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_${FFI_ARCH}/${FFI_ARCH}/$<CONFIG>/libffi.lib ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib/libffi.lib
+      #COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_${FFI_ARCH}/${FFI_ARCH}/$<CONFIG>/libffi.pdb ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib/libffi.pdb
   )
 
   configure_file("build_ruby.bat.in" "${CMAKE_BINARY_DIR}/build_ruby.bat.out")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ if (INTEGRATED_CONAN)
     ruby_installer/2.5.5@bincrafters/stable
     # cant use bison/3.5.3 from CCI as it uses m4 which won't build with x86. So use bincrafters' still but explicitly add bin dir to PATH later
     # bison_installer/3.3.2@bincrafters/stable
-    bison/3.7.1
+    bison/3.5.3
     zlib/1.2.11
     ${CONAN_FFI}
     ${CONAN_LIBYAML}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,9 @@ if (INTEGRATED_CONAN)
     list(APPEND CONAN_BUILD "zlib")
   endif()
   list(APPEND CONAN_OPTIONS "zlib:minizip=True")
-  list(APPEND CONAN_OPTIONS "gdbm:with_libiconv=True")
   list(APPEND CONAN_OPTIONS "gdbm:libgdbm_compat=True")
+  list(APPEND CONAN_OPTIONS "gdbm:with_libiconv=False")
+  list(APPEND CONAN_OPTIONS "gdbm:with_nls=False")
 
   # Passing shared=False is fine (but also already the default)
   # Passing fPIC=True is already the default on Unix, and doesn't exist on Windows (options is deleted in most recipes)
@@ -46,7 +47,6 @@ if (INTEGRATED_CONAN)
   #list(APPEND CONAN_OPTIONS "libyaml:shared=False")
   #list(APPEND CONAN_OPTIONS "gdbm:fPIC=True")
   #list(APPEND CONAN_OPTIONS "gdbm:shared=False")
-  #list(APPEND CONAN_OPTIONS "gdbm:libgdbm_compat=True")
   #list(APPEND CONAN_OPTIONS "readline:fPIC=True")
   #list(APPEND CONAN_OPTIONS "readline:shared=False")
   #list(APPEND CONAN_OPTIONS "fPIC=True")
@@ -65,7 +65,8 @@ if (INTEGRATED_CONAN)
     openssl/${OPENSSL_VERSION}
     ruby_installer/2.5.5@bincrafters/stable
     # cant use bison/3.5.3 from CCI as it uses m4 which won't build with x86. So use bincrafters' still but explicitly add bin dir to PATH later
-    bison_installer/3.3.2@bincrafters/stable
+    # bison_installer/3.3.2@bincrafters/stable
+    bison/3.5.3
     zlib/1.2.11
     ${CONAN_FFI}
     ${CONAN_LIBYAML}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,12 +29,8 @@ if (INTEGRATED_CONAN)
   conan_add_remote(NAME bincrafters
     URL https://api.bintray.com/conan/bincrafters/public-conan)
 
- # TODO: Temp
-  conan_add_remote(NAME jmarrec
-    URL https://api.bintray.com/conan/jmarrec/testing)
-
-
-
+  #conan_add_remote(NAME jmarrec
+  #  URL https://api.bintray.com/conan/jmarrec/testing)
 
   set(CONAN_BUILD "missing")
   if (APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if (INTEGRATED_CONAN)
   include(${CMAKE_BINARY_DIR}/conan.cmake)
   message("RUNNING CONAN")
 
-  conan_check(VERSION 1.25.0 REQUIRED)
+  conan_check(VERSION 1.24.0 REQUIRED)
 
   conan_add_remote(NAME bincrafters
     URL https://api.bintray.com/conan/bincrafters/public-conan)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ if (INTEGRATED_CONAN)
   conan_cmake_run(REQUIRES
     openssl/${OPENSSL_VERSION}
     ruby_installer/2.5.5@bincrafters/stable
+    bison_installer/3.3.2@bincrafters/stable
     zlib/1.2.11
     ${CONAN_FFI}
     ${CONAN_LIBYAML}
@@ -133,6 +134,8 @@ FindValue(CONAN_LIB_DIRS_READLINE)
 
 FindValue(CONAN_GMP_ROOT)
 FindValue(CONAN_LIB_DIRS_GMP)
+
+FindValue(CONAN_BIN_DIRS_BISON_INSTALLER)
 
 if(NOT UNIX)
   # conan-ffi doesn't link properly, so build from source.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,8 +65,7 @@ if (INTEGRATED_CONAN)
     openssl/${OPENSSL_VERSION}
     ruby_installer/2.5.5@bincrafters/stable
     # cant use bison/3.5.3 from CCI as it uses m4 which won't build with x86. So use bincrafters' still but explicitly add bin dir to PATH later
-    # bison_installer/3.3.2@bincrafters/stable
-    bison/3.5.3
+    bison_installer/3.3.2@bincrafters/stable
     zlib/1.2.11
     ${CONAN_FFI}
     ${CONAN_LIBYAML}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,8 @@ if (INTEGRATED_CONAN)
     openssl/${OPENSSL_VERSION}
     ruby_installer/2.5.5@bincrafters/stable
     # cant use bison/3.5.3 from CCI as it uses m4 which won't build with x86. So use bincrafters' still but explicitly add bin dir to PATH later
-    bison_installer/3.3.2@bincrafters/stable
+    # bison_installer/3.3.2@bincrafters/stable
+    bison/3.5.3
     zlib/1.2.11
     ${CONAN_FFI}
     ${CONAN_LIBYAML}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,8 +267,10 @@ else()
       DEPENDS ${CMAKE_BINARY_DIR}/tools/bin/sed.exe)
 
   set(FFI_ARCH "x64")
+  set(FFI_LIB_FOLDER "x64/")
   if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "4")
     set(FFI_ARCH "x86")
+    set(FFI_LIB_FOLDER "")
   endif()
 
   ## The libFFI provided by Conan gives us something we cannot link to for some reason (TBD)
@@ -285,8 +287,8 @@ else()
       COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/fficonfig.h ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/include/fficonfig.h
       COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/src/x86/ffitarget.h ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/include/ffitarget.h
       COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib
-      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_${FFI_ARCH}/x64/$<CONFIG>/libffi.lib ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib/libffi.lib
-      #COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_${FFI_ARCH}/x64/$<CONFIG>/libffi.pdb ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib/libffi.pdb
+      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_${FFI_ARCH}/${FFI_LIB_FOLDER}$<CONFIG>/libffi.lib ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib/libffi.lib
+      #COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_${FFI_ARCH}/${FFI_LIB_FOLDER}$<CONFIG>/libffi.pdb ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib/libffi.pdb
   )
 
   configure_file("build_ruby.bat.in" "${CMAKE_BINARY_DIR}/build_ruby.bat.out")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,12 @@ if (INTEGRATED_CONAN)
   conan_add_remote(NAME bincrafters
     URL https://api.bintray.com/conan/bincrafters/public-conan)
 
+ # TODO: Temp
+  conan_add_remote(NAME jmarrec
+    URL https://api.bintray.com/conan/jmarrec/testing)
+
+
+
 
   set(CONAN_BUILD "missing")
   if (APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if (INTEGRATED_CONAN)
   include(${CMAKE_BINARY_DIR}/conan.cmake)
   message("RUNNING CONAN")
 
-  conan_check(VERSION 1.18.0 REQUIRED)
+  conan_check(VERSION 1.25.0 REQUIRED)
 
   conan_add_remote(NAME bincrafters
     URL https://api.bintray.com/conan/bincrafters/public-conan)
@@ -51,11 +51,11 @@ if (INTEGRATED_CONAN)
   #list(APPEND CONAN_OPTIONS "libffi:shared=False")
 
   if(NOT MSVC)
-    set(CONAN_FFI "libffi/3.2.1")
+    set(CONAN_FFI "libffi/3.3")
     set(CONAN_LIBYAML "libyaml/0.2.2@bincrafters/stable")
-    set(CONAN_READLINE "readline/7.0@bincrafters/stable")
-    set(CONAN_GDBM "gdbm/1.18.1@bincrafters/stable")
-    set(CONAN_GMP "gmp/6.1.2")
+    set(CONAN_READLINE "readline/8.0")
+    set(CONAN_GDBM "gdbm/1.18.1")
+    set(CONAN_GMP "gmp/6.2.0")
   endif()
 
   conan_cmake_run(REQUIRES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,8 @@ if (INTEGRATED_CONAN)
     list(APPEND CONAN_BUILD "zlib")
   endif()
   list(APPEND CONAN_OPTIONS "zlib:minizip=True")
+  list(APPEND CONAN_OPTIONS "gdbm:with_libiconv=True")
+  list(APPEND CONAN_OPTIONS "gdbm:libgdbm_compat=True")
 
   # Passing shared=False is fine (but also already the default)
   # Passing fPIC=True is already the default on Unix, and doesn't exist on Windows (options is deleted in most recipes)
@@ -54,6 +56,7 @@ if (INTEGRATED_CONAN)
     set(CONAN_FFI "libffi/3.3")
     set(CONAN_LIBYAML "libyaml/0.2.2@bincrafters/stable")
     set(CONAN_READLINE "readline/8.0")
+    list(APPEND CONAN_OPTIONS "gdbm:with_readline=True")
     set(CONAN_GDBM "gdbm/1.18.1")
     set(CONAN_GMP "gmp/6.2.0")
   endif()
@@ -61,7 +64,7 @@ if (INTEGRATED_CONAN)
   conan_cmake_run(REQUIRES
     openssl/${OPENSSL_VERSION}
     ruby_installer/2.5.5@bincrafters/stable
-    bison_installer/3.3.2@bincrafters/stable
+    bison/3.5.3
     zlib/1.2.11
     ${CONAN_FFI}
     ${CONAN_LIBYAML}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ if (INTEGRATED_CONAN)
     ruby_installer/2.5.5@bincrafters/stable
     # cant use bison/3.5.3 from CCI as it uses m4 which won't build with x86. So use bincrafters' still but explicitly add bin dir to PATH later
     # bison_installer/3.3.2@bincrafters/stable
-    bison/3.5.3
+    bison/3.7.1
     zlib/1.2.11
     ${CONAN_FFI}
     ${CONAN_LIBYAML}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,10 +266,10 @@ else()
   add_custom_target(GetTools
       DEPENDS ${CMAKE_BINARY_DIR}/tools/bin/sed.exe)
 
-  set(FFI_ARCH "x64")
+  set(ARCH "x64")
   set(FFI_LIB_FOLDER "x64/")
   if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "4")
-    set(FFI_ARCH "x86")
+    set(ARCH "x86")
     set(FFI_LIB_FOLDER "")
   endif()
 
@@ -279,16 +279,16 @@ else()
     URL_HASH SHA256=bf6813045c0d470aedc3c69f9ec11fe351c2d7360c7d5396dc9a6ddc4830033c
     URL https://github.com/winlibs/libffi/archive/libffi-3.2.1.zip
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND devenv /upgrade ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_${FFI_ARCH}/libffi-msvc.sln
-      COMMAND msbuild ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_${FFI_ARCH}/libffi-msvc.sln /p:Configuration=$<CONFIG> /p:DefineConstants="FFI_BUILDING" "/p:Platform=${CMAKE_VS_PLATFORM_NAME}" "/p:WindowsTargetPlatformVersion=${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}"
+    BUILD_COMMAND devenv /upgrade ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_${ARCH}/libffi-msvc.sln
+      COMMAND msbuild ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_${ARCH}/libffi-msvc.sln /p:Configuration=$<CONFIG> /p:DefineConstants="FFI_BUILDING" "/p:Platform=${CMAKE_VS_PLATFORM_NAME}" "/p:WindowsTargetPlatformVersion=${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}"
     INSTALL_COMMAND ${CMAKE_COMMAND} -E remove_directory ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/
       COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/
       COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/include ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/include
       COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/fficonfig.h ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/include/fficonfig.h
       COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/src/x86/ffitarget.h ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/include/ffitarget.h
       COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib
-      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_${FFI_ARCH}/${FFI_LIB_FOLDER}$<CONFIG>/libffi.lib ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib/libffi.lib
-      #COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_${FFI_ARCH}/${FFI_LIB_FOLDER}$<CONFIG>/libffi.pdb ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib/libffi.pdb
+      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_${ARCH}/${FFI_LIB_FOLDER}$<CONFIG>/libffi.lib ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib/libffi.lib
+      #COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_${ARCH}/${FFI_LIB_FOLDER}$<CONFIG>/libffi.pdb ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib/libffi.pdb
   )
 
   configure_file("build_ruby.bat.in" "${CMAKE_BINARY_DIR}/build_ruby.bat.out")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ if (INTEGRATED_CONAN)
 
   conan_cmake_run(REQUIRES
     openssl/${OPENSSL_VERSION}
-    ruby_installer/2.5.5@jmarrec/testing # TODO: temp, revert to @bincrafters/stable
+    ruby_installer/2.5.5@bincrafters/stable
     zlib/1.2.11
     ${CONAN_FFI}
     ${CONAN_LIBYAML}
@@ -107,7 +107,7 @@ macro(FindValue ValueName)
   set(LocalVar $<$<CONFIG:Debug>:${${ValueName}_DEBUG}>$<$<CONFIG:Release>:${${ValueName}_RELEASE}>$<$<CONFIG:RelWithDebInfo>:${$ValueName}_RELWITHDEBINFO}>$<$<CONFIG:MinSizeRel>:${${ValueName}_MINSIZEREL}>
   )
 #  list(JOIN LocalVar "" LocalVar)
-  string(STRIP ${LocalVar} LocalVar)
+  string(STRIP "${LocalVar}" LocalVar)
   set(CURRENT_${ValueName} $<IF:$<BOOL:${LocalVar}>,${LocalVar},${${ValueName}}>)
   # For debug purposes
   # message(STATUS "Found '${ValueName}' as '${CURRENT_${ValueName}}'")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,8 @@ if (INTEGRATED_CONAN)
   conan_cmake_run(REQUIRES
     openssl/${OPENSSL_VERSION}
     ruby_installer/2.5.5@bincrafters/stable
-    bison/3.5.3
+    # cant use bison/3.5.3 from CCI as it uses m4 which won't build with x86. So use bincrafters' still but explicitly add bin dir to PATH later
+    bison_installer/3.3.2@bincrafters/stable
     zlib/1.2.11
     ${CONAN_FFI}
     ${CONAN_LIBYAML}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ if (INTEGRATED_CONAN)
 
   if(NOT MSVC)
     set(CONAN_FFI "libffi/3.3")
-    set(CONAN_LIBYAML "libyaml/0.2.2@bincrafters/stable")
+    set(CONAN_LIBYAML "libyaml/0.2.5")
     set(CONAN_READLINE "readline/8.0")
     list(APPEND CONAN_OPTIONS "gdbm:with_readline=True")
     set(CONAN_GDBM "gdbm/1.18.1")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,10 +283,10 @@ else()
       COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/
       COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/include ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/include
       COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/fficonfig.h ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/include/fficonfig.h
-      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/src/${FFI_ARCH}/ffitarget.h ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/include/ffitarget.h # THIS one had a x86 before?
+      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/src/x86/ffitarget.h ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/include/ffitarget.h
       COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib
-      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_${FFI_ARCH}/${FFI_ARCH}/$<CONFIG>/libffi.lib ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib/libffi.lib
-      #COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_${FFI_ARCH}/${FFI_ARCH}/$<CONFIG>/libffi.pdb ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib/libffi.pdb
+      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_${FFI_ARCH}/x64/$<CONFIG>/libffi.lib ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib/libffi.lib
+      #COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI/win32/vc14_${FFI_ARCH}/x64/$<CONFIG>/libffi.pdb ${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib/libffi.pdb
   )
 
   configure_file("build_ruby.bat.in" "${CMAKE_BINARY_DIR}/build_ruby.bat.out")

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ exporting the recipe from the conan-center-index repository. From the repository
 that you have the same hooks, etc, and there will be human errors.
 
 ```
-conan download zlib/1.2.11@ --recipe
+conan download -r nrel zlib/1.2.11@ --recipe
 conan install zlib/1.2.11@ -b zlib -o zlib:minizip=True -s build_type=Release
 conan install zlib/1.2.11@ -b zlib -o zlib:minizip=True -s build_type=Debug
 ```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
           CONAN_VISUAL_VERSIONS: 15
           CONAN_BUILD_TYPES: Debug
           CONAN_ARCHS: x86_64
-          CONAN_BUILD_REQUIRES: msys2/20190524
+          # CONAN_BUILD_REQUIRES: msys2/20190524
 
         # We now can support MSVC 2019: build both Release and Debug, x64 only
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,6 +42,10 @@ install:
   - pip.exe install conan --upgrade
   - pip.exe install conan_package_tools bincrafters_package_tools
   - conan user # It creates the conan data directory
+  - conan config install https://github.com/conan-io/hooks.git -sf hooks -tf hooks
+  - conan config set hooks.conan-center
+  - conan config set general.revisions_enabled=True
+  - conan config set general.parallel_download=8
 
 test_script:
 - python build.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
           CONAN_VISUAL_VERSIONS: 16
           CONAN_BUILD_TYPES: Release
           CONAN_ARCHS: x86
-          CONAN_BUILD_REQUIRES: msys2/20190524
+          # CONAN_BUILD_REQUIRES: msys2/20190524
 
         # We now can support MSVC 2019: build both Release and Debug, x64 only
         # This works under 1hr

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,23 +7,23 @@ environment:
 
     matrix:
 
-#        # 2017 is the target MSVC for now, so build Release and Debug, x64 only
-#        # I separate the release and debug because I'm hitting the 60 minute per build job Appveyor limit...
-#        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-#          CONAN_VISUAL_VERSIONS: 15
-#          CONAN_BUILD_TYPES: Release
-#          CONAN_ARCHS: x86_64
-#        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-#          CONAN_VISUAL_VERSIONS: 15
-#          CONAN_BUILD_TYPES: Debug
-#          CONAN_ARCHS: x86_64
-#          # CONAN_BUILD_REQUIRES: msys2/20190524
-#
-#        # We now can support MSVC 2019: build both Release and Debug, x64 only
-#        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-#          CONAN_VISUAL_VERSIONS: 16
-#          CONAN_BUILD_TYPES: Release
-#          CONAN_ARCHS: x86_64
+        # 2017 is the target MSVC for now, so build Release and Debug, x64 only
+        # I separate the release and debug because I'm hitting the 60 minute per build job Appveyor limit...
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          CONAN_BUILD_TYPES: Release
+          CONAN_ARCHS: x86_64
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          CONAN_BUILD_TYPES: Debug
+          CONAN_ARCHS: x86_64
+          # CONAN_BUILD_REQUIRES: msys2/20190524
+
+        # We now can support MSVC 2019: build both Release and Debug, x64 only
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+          CONAN_VISUAL_VERSIONS: 16
+          CONAN_BUILD_TYPES: Release
+          CONAN_ARCHS: x86_64
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
           CONAN_VISUAL_VERSIONS: 16
           CONAN_BUILD_TYPES: Debug

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,7 @@ environment:
           CONAN_VISUAL_VERSIONS: 15
           CONAN_BUILD_TYPES: Debug
           CONAN_ARCHS: x86_64
+          CONAN_BUILD_REQUIRES: msys2/20190524
 
         # We now can support MSVC 2019: build both Release and Debug, x64 only
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ build: false
 environment:
     PYTHON_HOME: "C:\\Python37"
     CONAN_VISUAL_RUNTIMES: MD,MDd   # Ignoring MT and MTd
-    CONAN_ARCHS: x86_64   # Don't want to build for x86
+    # CONAN_ARCHS: x86_64,   # Don't want to build for x86
 
     matrix:
 
@@ -12,15 +12,24 @@ environment:
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
           CONAN_VISUAL_VERSIONS: 16
           CONAN_BUILD_TYPES: Release,Debug
+          CONAN_ARCHS: x86_64
 
         # 2017 is the target MSVC for now, so build Release and Debug, x64 only
         # I separate the release and debug because I'm hitting the 60 minute per build job Appveyor limit...
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
           CONAN_BUILD_TYPES: Release
+          CONAN_ARCHS: x86_64
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
           CONAN_BUILD_TYPES: Debug
+          CONAN_ARCHS: x86_64
+
+        # Try a Release build on 32bit
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+          CONAN_VISUAL_VERSIONS: 16
+          CONAN_BUILD_TYPES: Release
+          CONAN_ARCHS: x86
 
 install:
   - set PATH=%PYTHON_HOME%;%PYTHON_HOME%/Scripts/;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,10 +8,12 @@ environment:
     matrix:
 
         # Try a Release build on 32bit
+        # Pending https://github.com/conan-io/conan-center-index/pull/2298 we need to force require msys2
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
           CONAN_VISUAL_VERSIONS: 16
           CONAN_BUILD_TYPES: Release
           CONAN_ARCHS: x86
+          CONAN_BUILD_REQUIRES: msys2/20190524
 
         # We now can support MSVC 2019: build both Release and Debug, x64 only
         # This works under 1hr

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ environment:
           CONAN_VISUAL_VERSIONS: 16
           CONAN_BUILD_TYPES: Release
           CONAN_ARCHS: x86
-          CONAN_BUILD_REQUIRES: msys2/20190524
+          # CONAN_BUILD_REQUIRES: msys2/20190524
 
 install:
   - set PATH=%PYTHON_HOME%;%PYTHON_HOME%/Scripts/;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
         # This works under 1hr
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
           CONAN_VISUAL_VERSIONS: 16
-          CONAN_BUILD_TYPES: Release,Debug
+          CONAN_BUILD_TYPES: Release
           CONAN_ARCHS: x86_64
 
         # 2017 is the target MSVC for now, so build Release and Debug, x64 only
@@ -26,10 +26,10 @@ environment:
           CONAN_VISUAL_VERSIONS: 15
           CONAN_BUILD_TYPES: Release
           CONAN_ARCHS: x86_64
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-          CONAN_VISUAL_VERSIONS: 15
-          CONAN_BUILD_TYPES: Debug
-          CONAN_ARCHS: x86_64
+        #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          #CONAN_VISUAL_VERSIONS: 15
+          #CONAN_BUILD_TYPES: Debug
+          #CONAN_ARCHS: x86_64
 
 install:
   - set PATH=%PYTHON_HOME%;%PYTHON_HOME%/Scripts/;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,6 +46,8 @@ install:
   - conan config set hooks.conan-center
   - conan config set general.revisions_enabled=True
   - conan config set general.parallel_download=8
+  # Already done in the appveyor settings
+  # - conan remote update nrel https://api.bintray.com/conan/commercialbuilding/nrel --insert 0
 
 test_script:
 - python build.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
         # This works under 1hr
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
           CONAN_VISUAL_VERSIONS: 16
-          CONAN_BUILD_TYPES: Release
+          CONAN_BUILD_TYPES: Release,Debug
           CONAN_ARCHS: x86_64
 
         # 2017 is the target MSVC for now, so build Release and Debug, x64 only
@@ -26,10 +26,10 @@ environment:
           CONAN_VISUAL_VERSIONS: 15
           CONAN_BUILD_TYPES: Release
           CONAN_ARCHS: x86_64
-        #- APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-          #CONAN_VISUAL_VERSIONS: 15
-          #CONAN_BUILD_TYPES: Debug
-          #CONAN_ARCHS: x86_64
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          CONAN_BUILD_TYPES: Debug
+          CONAN_ARCHS: x86_64
 
 install:
   - set PATH=%PYTHON_HOME%;%PYTHON_HOME%/Scripts/;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,21 +7,6 @@ environment:
 
     matrix:
 
-        # Try a Release build on 32bit
-        # Pending https://github.com/conan-io/conan-center-index/pull/2298 we need to force require msys2
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-          CONAN_VISUAL_VERSIONS: 16
-          CONAN_BUILD_TYPES: Release
-          CONAN_ARCHS: x86
-          # CONAN_BUILD_REQUIRES: msys2/20190524
-
-        # We now can support MSVC 2019: build both Release and Debug, x64 only
-        # This works under 1hr
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-          CONAN_VISUAL_VERSIONS: 16
-          CONAN_BUILD_TYPES: Release,Debug
-          CONAN_ARCHS: x86_64
-
         # 2017 is the target MSVC for now, so build Release and Debug, x64 only
         # I separate the release and debug because I'm hitting the 60 minute per build job Appveyor limit...
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
@@ -32,6 +17,24 @@ environment:
           CONAN_VISUAL_VERSIONS: 15
           CONAN_BUILD_TYPES: Debug
           CONAN_ARCHS: x86_64
+
+        # We now can support MSVC 2019: build both Release and Debug, x64 only
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+          CONAN_VISUAL_VERSIONS: 16
+          CONAN_BUILD_TYPES: Release
+          CONAN_ARCHS: x86_64
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+          CONAN_VISUAL_VERSIONS: 16
+          CONAN_BUILD_TYPES: Debug
+          CONAN_ARCHS: x86_64
+
+        # Try a Release build on 32bit
+        # Pending https://github.com/conan-io/conan-center-index/pull/2298 we need to force require msys2
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+          CONAN_VISUAL_VERSIONS: 16
+          CONAN_BUILD_TYPES: Release
+          CONAN_ARCHS: x86
+          CONAN_BUILD_REQUIRES: msys2/20190524
 
 install:
   - set PATH=%PYTHON_HOME%;%PYTHON_HOME%/Scripts/;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,23 +7,23 @@ environment:
 
     matrix:
 
-        # 2017 is the target MSVC for now, so build Release and Debug, x64 only
-        # I separate the release and debug because I'm hitting the 60 minute per build job Appveyor limit...
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-          CONAN_VISUAL_VERSIONS: 15
-          CONAN_BUILD_TYPES: Release
-          CONAN_ARCHS: x86_64
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-          CONAN_VISUAL_VERSIONS: 15
-          CONAN_BUILD_TYPES: Debug
-          CONAN_ARCHS: x86_64
-          # CONAN_BUILD_REQUIRES: msys2/20190524
-
-        # We now can support MSVC 2019: build both Release and Debug, x64 only
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-          CONAN_VISUAL_VERSIONS: 16
-          CONAN_BUILD_TYPES: Release
-          CONAN_ARCHS: x86_64
+#        # 2017 is the target MSVC for now, so build Release and Debug, x64 only
+#        # I separate the release and debug because I'm hitting the 60 minute per build job Appveyor limit...
+#        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+#          CONAN_VISUAL_VERSIONS: 15
+#          CONAN_BUILD_TYPES: Release
+#          CONAN_ARCHS: x86_64
+#        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+#          CONAN_VISUAL_VERSIONS: 15
+#          CONAN_BUILD_TYPES: Debug
+#          CONAN_ARCHS: x86_64
+#          # CONAN_BUILD_REQUIRES: msys2/20190524
+#
+#        # We now can support MSVC 2019: build both Release and Debug, x64 only
+#        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+#          CONAN_VISUAL_VERSIONS: 16
+#          CONAN_BUILD_TYPES: Release
+#          CONAN_ARCHS: x86_64
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
           CONAN_VISUAL_VERSIONS: 16
           CONAN_BUILD_TYPES: Debug

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,30 +7,28 @@ environment:
 
     matrix:
 
-        # 2017 is the target MSVC for now, so build Release and Debug, x64 only
-        # I separate the release and debug because I'm hitting the 60 minute per build job Appveyor limit...
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-          CONAN_VISUAL_VERSIONS: 15
+        # We can support MSVC 2019: build both Release and Debug, x64 only
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+          CONAN_VISUAL_VERSIONS: 16
           CONAN_BUILD_TYPES: Release
           CONAN_ARCHS: x86_64
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-          CONAN_VISUAL_VERSIONS: 15
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+          CONAN_VISUAL_VERSIONS: 16
           CONAN_BUILD_TYPES: Debug
           CONAN_ARCHS: x86_64
-          # CONAN_BUILD_REQUIRES: msys2/20190524
 
-        # We now can support MSVC 2019: build both Release and Debug, x64 only
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-          CONAN_VISUAL_VERSIONS: 16
+        # Let's still support 2017, so build Release and Debug, x64 only
+        # I separate the release and debug because I'm hitting the 60 minute per build job Appveyor limit... seems like the MSVC 17 image has much less resources than 19
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
           CONAN_BUILD_TYPES: Release
           CONAN_ARCHS: x86_64
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-          CONAN_VISUAL_VERSIONS: 16
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
           CONAN_BUILD_TYPES: Debug
           CONAN_ARCHS: x86_64
 
         # Try a Release build on 32bit
-        # Pending https://github.com/conan-io/conan-center-index/pull/2298 we need to force require msys2
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
           CONAN_VISUAL_VERSIONS: 16
           CONAN_BUILD_TYPES: Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,12 @@ environment:
 
     matrix:
 
+        # Try a Release build on 32bit
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+          CONAN_VISUAL_VERSIONS: 16
+          CONAN_BUILD_TYPES: Release
+          CONAN_ARCHS: x86
+
         # We now can support MSVC 2019: build both Release and Debug, x64 only
         # This works under 1hr
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
@@ -24,12 +30,6 @@ environment:
           CONAN_VISUAL_VERSIONS: 15
           CONAN_BUILD_TYPES: Debug
           CONAN_ARCHS: x86_64
-
-        # Try a Release build on 32bit
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-          CONAN_VISUAL_VERSIONS: 16
-          CONAN_BUILD_TYPES: Release
-          CONAN_ARCHS: x86
 
 install:
   - set PATH=%PYTHON_HOME%;%PYTHON_HOME%/Scripts/;%PATH%

--- a/build.py
+++ b/build.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     # When pure_c is False, it  will create, for GCC >=5, one build for
     # compiler.libcxx=libstdc++ and one for compiler.libcxx=libstc++11.
     # Then we filter the old ABI ones out since that will never happen
-    # wheb run from OpenStudio's CMake
+    # when run from OpenStudio's CMake
     # cf: https://docs.conan.io/en/latest/howtos/manage_gcc_abi.html
     pure_c = False
 

--- a/build.py
+++ b/build.py
@@ -6,6 +6,9 @@ from cpt.printer import Printer
 from cpt.ci_manager import CIManager
 from bincrafters import build_template_default
 
+# Debug
+import glob as gb
+
 if __name__ == "__main__":
 
     # CONAN_STABLE_PATTERN env variable is used to set:
@@ -57,5 +60,16 @@ if __name__ == "__main__":
                                 "bison:build_type": "Release",
                                 "ruby_installer:build_type": "Release",
                             })
+    try:
+        builder.run()
+    except:
+        for p in gb.glob(os.path.join(os.path.expanduser("~"), ".conan", "data", "bison", "**", "config.log"), recursive=True)
+            with open(p, 'r') as f:
+                content = f.read()
 
-    builder.run()
+            print("=========================================================")
+            print(p)
+            print("---------------------------------------------------------")
+            print(content)
+            print("=========================================================")
+

--- a/build.py
+++ b/build.py
@@ -63,7 +63,9 @@ if __name__ == "__main__":
     try:
         builder.run()
     except:
-        for p in gb.glob(os.path.join(os.path.expanduser("~"), ".conan", "data", "bison", "**", "config.log"), recursive=True)
+        for p in gb.glob(os.path.join(os.path.expanduser("~"), ".conan",
+                                      "data", "bison", "**", "config.log"),
+                         recursive=True):
             with open(p, 'r') as f:
                 content = f.read()
 

--- a/build.py
+++ b/build.py
@@ -60,18 +60,22 @@ if __name__ == "__main__":
                                 "bison:build_type": "Release",
                                 "ruby_installer:build_type": "Release",
                             })
-    try:
-        builder.run()
-    except:
-        for p in gb.glob(os.path.join(os.path.expanduser("~"), ".conan",
-                                      "data", "bison", "**", "config.log"),
-                         recursive=True):
-            with open(p, 'r') as f:
-                content = f.read()
 
-            print("=========================================================")
-            print(p)
-            print("---------------------------------------------------------")
-            print(content)
-            print("=========================================================")
+    builder.run()
+
+    # Debug
+    # try:
+    #     builder.run()
+    # except:
+    #     for p in gb.glob(os.path.join(os.path.expanduser("~"), ".conan",
+    #                                   "data", "bison", "**", "config.log"),
+    #                      recursive=True):
+    #         with open(p, 'r') as f:
+    #             content = f.read()
+
+    #         print("========================================================")
+    #         print(p)
+    #         print("--------------------------------------------------------")
+    #         print(content)
+    #         print("========================================================")
 

--- a/build.py
+++ b/build.py
@@ -51,4 +51,11 @@ if __name__ == "__main__":
                       (build.settings["compiler.libcxx"] != "libstdc++11")
     )
 
+    # There's no reason to use Debug builds of the build_requirements at least
+    builder.update_build_if(lambda build: True,
+                            new_settings={
+                                "bison:build_type": "Release",
+                                "ruby_installer:build_type": "Release",
+                            })
+
     builder.run()

--- a/build.py
+++ b/build.py
@@ -55,11 +55,11 @@ if __name__ == "__main__":
     )
 
     # There's no reason to use Debug builds of the build_requirements at least
-    builder.update_build_if(lambda build: True,
-                            new_settings={
-                                "bison:build_type": "Release",
-                                "ruby_installer:build_type": "Release",
-                            })
+    # builder.update_build_if(lambda build: True,
+                            # new_settings={
+                                # "bison:build_type": "Release",
+                                # "ruby_installer:build_type": "Release",
+                            # })
 
     builder.run()
 

--- a/build_ruby.bat.in
+++ b/build_ruby.bat.in
@@ -86,7 +86,3 @@ for /R "${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-build/ext/" %%f in (*.lib) do (
 for /R "${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-build/enc/" %%f in (*.lib) do (
   "${CMAKE_COMMAND}" -E copy_if_different %%f "${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/lib/enc/"
 )
-
-IF "%ARCH%" == "x86" (
-    "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-build/rbconfig.rb" "${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/lib/ruby/2.5.0/rbconfig.rb"
-)

--- a/build_ruby.bat.in
+++ b/build_ruby.bat.in
@@ -25,7 +25,7 @@ set LIBFFI_LIBS=${CURRENT_CONAN_LIB_DIRS_LIBFFI}/libffi.lib
 set LIBYAML_DIR=${CURRENT_CONAN_LIBYAML_ROOT}
 set LIBYAML_LIBS=${CURRENT_CONAN_LIB_DIRS_LIBYAML}/yaml.lib
 
-set PATH=${CMAKE_BINARY_DIR}/tools/bin;%PATH%
+set PATH=${CMAKE_BINARY_DIR}/tools/bin;${CONAN_BIN_DIRS_BISON_INSTALLER};%PATH%
 
 @ECHO OFF
 
@@ -88,5 +88,5 @@ for /R "${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-build/enc/" %%f in (*.lib) do (
 )
 
 IF "%ARCH%" == "x86" (
-    "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/lib/ruby/2.5.0/i386-mswin32_140/rbconfig.rb" "${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/lib/ruby/2.5.0/rbconfig.rb"
+    "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-build/rbconfig.rb" "${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/lib/ruby/2.5.0/rbconfig.rb"
 )

--- a/build_ruby.bat.in
+++ b/build_ruby.bat.in
@@ -61,7 +61,7 @@ IF "%LIBYAML_DIR%" == "" (
     ECHO "LibYAML defined: %LIBYAML_DIR%"
 )
 IF "%ARCH%" == "x64" (
-  set CONF_ARGS=%CONF_ARGS% --target=x64-mswin64"
+    set CONF_ARGS=%CONF_ARGS% --target=x64-mswin64"
 )
 echo "New Flags %CFLAGS%"
 echo "EXTLIBS='%EXTLIBS%'"
@@ -87,3 +87,6 @@ for /R "${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-build/enc/" %%f in (*.lib) do (
   "${CMAKE_COMMAND}" -E copy_if_different %%f "${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/lib/enc/"
 )
 
+IF "%ARCH%" == "x86" (
+    "${CMAKE_COMMAND}" -E copy_if_different "${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/lib/ruby/2.5.0/i386-mswin32_140/rbconfig.rb" "${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/lib/ruby/2.5.0/rbconfig.rb"
+)

--- a/build_ruby.bat.in
+++ b/build_ruby.bat.in
@@ -60,14 +60,16 @@ IF "%LIBYAML_DIR%" == "" (
     set CONF_ARGS=%CONF_ARGS% --with-libyaml-dir="%LIBYAML_DIR%"
     ECHO "LibYAML defined: %LIBYAML_DIR%"
 )
-
+IF "%ARCH%" == "x64" (
+  set CONF_ARGS=%CONF_ARGS% --target=x64-mswin64"
+)
 echo "New Flags %CFLAGS%"
 echo "EXTLIBS='%EXTLIBS%'"
 echo "CONF_ARGS='%CONF_ARGS%'"
 
 @ECHO ON
 
-call ${CMAKE_BINARY_DIR}\Ruby-prefix\src\Ruby\win32\configure.bat --with-static-linked-ext %CONF_ARGS% --without-win32ole --disable-install-doc --prefix="${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/" --target=x64-mswin64 --with-baseruby="%BASE_RUBY%" 
+call ${CMAKE_BINARY_DIR}\Ruby-prefix\src\Ruby\win32\configure.bat --with-static-linked-ext %CONF_ARGS% --without-win32ole --disable-install-doc --prefix="${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/" --with-baseruby="%BASE_RUBY%" 
 
 nmake /k
 nmake /k install-nodoc

--- a/conanfile.py
+++ b/conanfile.py
@@ -98,7 +98,7 @@ class OpenstudiorubyConan(ConanFile):
             self.options["gdbm"].shared = False
             # self.options["gdbm"].fPIC = True
             self.options["gdbm"].libgdbm_compat = True
-            self.options["gdbm"].with_libiconv = True
+            self.options["gdbm"].with_libiconv = False
             self.options["gdbm"].with_nls = False
             if self.options.with_readline:
                 self.options["gdbm"].with_readline = True

--- a/conanfile.py
+++ b/conanfile.py
@@ -137,8 +137,6 @@ class OpenstudiorubyConan(ConanFile):
 
         # You CANNOT use bison 3.7.1 as it's stricter and will throw
         # redefinition errors in Ruby' parser.c
-        # I had to patch bison 3.5.3 and upload it to NREL's remote to remove
-        # the YACC env variable
         self.build_requires("bison/3.5.3")
 
     def build(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -123,6 +123,8 @@ class OpenstudiorubyConan(ConanFile):
         # with x86. So use bincrafters' still but explicitly add bin dir
         # to PATH later in CMakeLists.txt
         # self.build_requires("bison/3.5.3")
+        # TODO: once https://github.com/conan-io/conan-center-index/pull/2250
+        # is merged, revisit this
         self.build_requires("bison_installer/3.3.2@bincrafters/stable")
 
     def build(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -92,6 +92,9 @@ class OpenstudiorubyConan(ConanFile):
             self.options["gdbm"].shared = False
             # self.options["gdbm"].fPIC = True
             self.options["gdbm"].libgdbm_compat = True
+            self.options["gdbm"].with_libiconv = True
+            if self.options.with_readline:
+                self.options["gdbm"].with_readline = True
 
         if self.options.with_readline:
             self.requires("readline/8.0")
@@ -109,7 +112,7 @@ class OpenstudiorubyConan(ConanFile):
         not be retrieved.
         """
         self.build_requires("ruby_installer/2.5.5@bincrafters/stable")
-        self.build_requires("bison_installer/3.3.2@bincrafters/stable")
+        self.build_requires("bison/3.5.3")
 
     def build(self):
         """

--- a/conanfile.py
+++ b/conanfile.py
@@ -83,23 +83,23 @@ class OpenstudiorubyConan(ConanFile):
             # self.options["libyaml"].fPIC = True
 
         if self.options.with_libffi:
-            self.requires("libffi/3.2.1")
+            self.requires("libffi/3.3")
             self.options["libffi"].shared = False
             # self.options["libffi"].fPIC = True
 
         if self.options.with_gdbm:
-            self.requires("gdbm/1.18.1@bincrafters/stable")
+            self.requires("gdbm/1.18.1")
             self.options["gdbm"].shared = False
             # self.options["gdbm"].fPIC = True
             self.options["gdbm"].libgdbm_compat = True
 
         if self.options.with_readline:
-            self.requires("readline/7.0@bincrafters/stable")
+            self.requires("readline/8.0")
             # self.options["readline"].shared = True
             # self.options["readline"].fPIC = True
 
         if self.options.with_gmp:
-            self.requires("gmp/6.1.2")
+            self.requires("gmp/6.2.0")
 
     def build_requirements(self):
         """

--- a/conanfile.py
+++ b/conanfile.py
@@ -78,13 +78,13 @@ class OpenstudiorubyConan(ConanFile):
         self.requires("zlib/1.2.11")
 
         if self.options.with_libyaml:
-            self.requires("libyaml/0.2.2@bincrafters/stable")
-            self.options["libyaml"].shared = False
+            self.requires("libyaml/0.2.5")
+            # self.options["libyaml"].shared = False
             # self.options["libyaml"].fPIC = True
 
         if self.options.with_libffi:
             self.requires("libffi/3.3")
-            self.options["libffi"].shared = False
+            # self.options["libffi"].shared = False
             # self.options["libffi"].fPIC = True
 
         if self.options.with_gdbm:
@@ -95,8 +95,8 @@ class OpenstudiorubyConan(ConanFile):
             # the conan-center one...
             # `conan remote update nrel https://api.bintray.com/conan/commercialbuilding/nrel --insert 0`
             self.requires("gdbm/1.18.1")
-            self.options["gdbm"].shared = False
-            self.options["gdbm"].fPIC = True
+            # self.options["gdbm"].shared = False
+            # self.options["gdbm"].fPIC = True
             self.options["gdbm"].libgdbm_compat = True
             self.options["gdbm"].with_libiconv = False
             self.options["gdbm"].with_nls = False

--- a/conanfile.py
+++ b/conanfile.py
@@ -147,6 +147,7 @@ class OpenstudiorubyConan(ConanFile):
 
         eg:
             include/ruby-2.5.0/x64-mswin64_140
+            include/ruby-2.5.0/i386-mswin32_140
             include/ruby-2.5.0/x86_64-linux
             include/ruby-2.5.0/x86_64-darwin17
         """
@@ -211,7 +212,7 @@ class OpenstudiorubyConan(ConanFile):
 
         # Remove the non-static VS libs
         if self.settings.os == "Windows":
-            non_stat_re = re.compile(r'x64-vcruntime[0-9]+-ruby[0-9]+\.lib')
+            non_stat_re = re.compile(r'(x64-)?vcruntime[0-9]+-ruby[0-9]+\.lib')
             exclude_libs = [x for x in libs
                             if non_stat_re.search(x)]
             if not exclude_libs:
@@ -263,63 +264,72 @@ class OpenstudiorubyConan(ConanFile):
                              ext_libs)
 
         elif self.settings.os == 'Windows':
-            expected_libs = (['x64-vcruntime140-ruby250-static.lib'] +
-                             ext_libs)
+            # bignum-i386-mswin32_140.lib
+            # bignum-x64-mswin64_140.lib
+            if self.settings.arch == "x86":
+                libarch = "i386-mswin32_140"
+                expected_libs = (['vcruntime140-ruby250-static.lib'] +
+                                 ext_libs)
+            else:
+                libarch = "x64-mswin64_140"
+                expected_libs = (['x64-vcruntime140-ruby250-static.lib'] +
+                                 ext_libs)
 
-            expected_libs += ['at_exit-x64-mswin64_140.lib',
-                              'bignum-x64-mswin64_140.lib',
-                              'bug_3571-x64-mswin64_140.lib',
-                              'bug_5832-x64-mswin64_140.lib',
-                              'bug_reporter-x64-mswin64_140.lib',
-                              'call_without_gvl-x64-mswin64_140.lib',
-                              'class-x64-mswin64_140.lib',
-                              'compat-x64-mswin64_140.lib',
-                              'console-x64-mswin64_140.lib',
-                              'debug-x64-mswin64_140.lib',
-                              'dln-x64-mswin64_140.lib',
-                              'dot.dot-x64-mswin64_140.lib',
-                              'empty-x64-mswin64_140.lib',
-                              'exception-x64-mswin64_140.lib',
-                              'fd_setsize-x64-mswin64_140.lib',
-                              'file-x64-mswin64_140.lib',
-                              'float-x64-mswin64_140.lib',
-                              'foreach-x64-mswin64_140.lib',
-                              'funcall-x64-mswin64_140.lib',
-                              'hash-x64-mswin64_140.lib',
-                              'integer-x64-mswin64_140.lib',
-                              'internal_ivar-x64-mswin64_140.lib',
-                              'iseq_load-x64-mswin64_140.lib',
-                              'iter-x64-mswin64_140.lib',
-                              'memory_status-x64-mswin64_140.lib',
-                              'method-x64-mswin64_140.lib',
-                              'notimplement-x64-mswin64_140.lib',
-                              'num2int-x64-mswin64_140.lib',
-                              'numhash-x64-mswin64_140.lib',
-                              'path_to_class-x64-mswin64_140.lib',
-                              'postponed_job-x64-mswin64_140.lib',
-                              'printf-x64-mswin64_140.lib',
-                              'proc-x64-mswin64_140.lib',
-                              'protect-x64-mswin64_140.lib',
-                              'rational-x64-mswin64_140.lib',
-                              'rb_fatal-x64-mswin64_140.lib',
-                              'recursion-x64-mswin64_140.lib',
-                              'regexp-x64-mswin64_140.lib',
-                              'resize-x64-mswin64_140.lib',
-                              'scan_args-x64-mswin64_140.lib',
-                              'string-x64-mswin64_140.lib',
-                              'struct-x64-mswin64_140.lib',
-                              'symbol-x64-mswin64_140.lib',
-                              'thread_fd_close-x64-mswin64_140.lib',
-                              'time-x64-mswin64_140.lib',
-                              'tracepoint-x64-mswin64_140.lib',
-                              'typeddata-x64-mswin64_140.lib',
-                              'update-x64-mswin64_140.lib',
-                              'usr-x64-mswin64_140.lib',
-                              'wait_for_single_fd-x64-mswin64_140.lib']
-
+            expected_libs += ['at_exit-{l}.lib',
+                              'bignum-{l}.lib',
+                              'bug_3571-{l}.lib',
+                              'bug_5832-{l}.lib',
+                              'bug_reporter-{l}.lib',
+                              'call_without_gvl-{l}.lib',
+                              'class-{l}.lib',
+                              'compat-{l}.lib',
+                              'console-{l}.lib',
+                              'debug-{l}.lib',
+                              'dln-{l}.lib',
+                              'dot.dot-{l}.lib',
+                              'empty-{l}.lib',
+                              'exception-{l}.lib',
+                              'fd_setsize-{l}.lib',
+                              'file-{l}.lib',
+                              'float-{l}.lib',
+                              'foreach-{l}.lib',
+                              'funcall-{l}.lib',
+                              'hash-{l}.lib',
+                              'integer-{l}.lib',
+                              'internal_ivar-{l}.lib',
+                              'iseq_load-{l}.lib',
+                              'iter-{l}.lib',
+                              'memory_status-{l}.lib',
+                              'method-{l}.lib',
+                              'notimplement-{l}.lib',
+                              'num2int-{l}.lib',
+                              'numhash-{l}.lib',
+                              'path_to_class-{l}.lib',
+                              'postponed_job-{l}.lib',
+                              'printf-{l}.lib',
+                              'proc-{l}.lib',
+                              'protect-{l}.lib',
+                              'rational-{l}.lib',
+                              'rb_fatal-{l}.lib',
+                              'recursion-{l}.lib',
+                              'regexp-{l}.lib',
+                              'resize-{l}.lib',
+                              'scan_args-{l}.lib',
+                              'string-{l}.lib',
+                              'struct-{l}.lib',
+                              'symbol-{l}.lib',
+                              'thread_fd_close-{l}.lib',
+                              'time-{l}.lib',
+                              'tracepoint-{l}.lib',
+                              'typeddata-{l}.lib',
+                              'update-{l}.lib',
+                              'usr-{l}.lib',
+                              'wait_for_single_fd-{l}.lib']
+            expected_libs = [x.format(l=libarch) for x in expected_libs]
 
             self.output.warn(
-                "Since we are building a custom libffi, we are packaging it, as it's required for linking our ruby")
+                "Since we are building a custom libffi, we are packaging it, "
+                "as it's required for linking our ruby")
             expected_libs += ['libffi.lib']
 
         n_libs = len(libs)

--- a/conanfile.py
+++ b/conanfile.py
@@ -122,10 +122,10 @@ class OpenstudiorubyConan(ConanFile):
         # cant use bison/3.5.3 from CCI as it uses m4 which won't build
         # with x86. So use bincrafters' still but explicitly add bin dir
         # to PATH later in CMakeLists.txt
-        self.build_requires("bison/3.5.3")
+        # self.build_requires("bison/3.5.3")
         # TODO: once https://github.com/conan-io/conan-center-index/pull/2250
-        # is merged, revisit this
-        # self.build_requires("bison_installer/3.3.2@bincrafters/stable")
+        # is merged, revisit this. Edit: PR merged but still another problem...
+        self.build_requires("bison_installer/3.3.2@bincrafters/stable")
 
     def build(self):
         """

--- a/conanfile.py
+++ b/conanfile.py
@@ -118,7 +118,11 @@ class OpenstudiorubyConan(ConanFile):
         not be retrieved.
         """
         self.build_requires("ruby_installer/2.5.5@bincrafters/stable")
-        self.build_requires("bison/3.5.3")
+        # cant use bison/3.5.3 from CCI as it uses m4 which won't build
+        # with x86. So use bincrafters' still but explicitly add bin dir
+        # to PATH later in CMakeLists.txt
+        # self.build_requires("bison/3.5.3")
+        self.build_requires("bison_installer/3.3.2@bincrafters/stable")
 
     def build(self):
         """

--- a/conanfile.py
+++ b/conanfile.py
@@ -122,12 +122,19 @@ class OpenstudiorubyConan(ConanFile):
         # cant use bison/3.5.3 from CCI as it uses m4 which won't build
         # with x86. So use bincrafters' still but explicitly add bin dir
         # to PATH later in CMakeLists.txt
-        self.build_requires("bison/3.5.3")
+        # self.build_requires("bison/3.5.3")
         # TODO: once https://github.com/conan-io/conan-center-index/pull/2250
         # is merged, revisit this. Edit: PR merged but still another problem...
         # Pending https://github.com/conan-io/conan-center-index/pull/2298
         # I'm using a special CONAN_BUILD_REQUIRES env var for win x86
         # self.build_requires("bison_installer/3.3.2@bincrafters/stable")
+        # Yet it still doesn't work, since bison ITSELF has a problem with x86
+        # names
+        if self.settings.os == "Windows" and self.settings.arch == 'x86':
+            self.build_requires("bison_installer/3.3.2@bincrafters/stable")
+        else:
+            self.build_requires("bison/3.5.3")
+
 
     def build(self):
         """

--- a/conanfile.py
+++ b/conanfile.py
@@ -130,11 +130,10 @@ class OpenstudiorubyConan(ConanFile):
         # self.build_requires("bison_installer/3.3.2@bincrafters/stable")
         # Yet it still doesn't work, since bison ITSELF has a problem with x86
         # names
-        if self.settings.os == "Windows" and self.settings.arch == 'x86':
-            self.build_requires("bison_installer/3.3.2@bincrafters/stable")
-        else:
-            self.build_requires("bison/3.5.3")
-
+        # if self.settings.os == "Windows" and self.settings.arch == 'x86':
+        #     self.build_requires("bison_installer/3.3.2@bincrafters/stable")
+        # else:
+        self.build_requires("bison/3.7.1")
 
     def build(self):
         """

--- a/conanfile.py
+++ b/conanfile.py
@@ -133,7 +133,7 @@ class OpenstudiorubyConan(ConanFile):
         # if self.settings.os == "Windows" and self.settings.arch == 'x86':
         #     self.build_requires("bison_installer/3.3.2@bincrafters/stable")
         # else:
-        self.build_requires("bison/3.5.3")
+        self.build_requires("bison/3.7.1")
 
     def build(self):
         """

--- a/conanfile.py
+++ b/conanfile.py
@@ -133,7 +133,7 @@ class OpenstudiorubyConan(ConanFile):
         # if self.settings.os == "Windows" and self.settings.arch == 'x86':
         #     self.build_requires("bison_installer/3.3.2@bincrafters/stable")
         # else:
-        self.build_requires("bison/3.7.1")
+        self.build_requires("bison/3.5.3")
 
     def build(self):
         """

--- a/conanfile.py
+++ b/conanfile.py
@@ -109,7 +109,7 @@ class OpenstudiorubyConan(ConanFile):
         not be retrieved.
         """
         self.build_requires("ruby_installer/2.5.5@bincrafters/stable")
-        self.build_requires("bison_installer/3.3.2@bincrafters/stable")
+        self.build_requires("bison/3.5.3")
 
     def build(self):
         """

--- a/conanfile.py
+++ b/conanfile.py
@@ -98,9 +98,9 @@ class OpenstudiorubyConan(ConanFile):
             self.options["gdbm"].shared = False
             # self.options["gdbm"].fPIC = True
             self.options["gdbm"].libgdbm_compat = True
-            self.options["gdbm"].with_libiconv = True
-            if self.options.with_readline:
-                self.options["gdbm"].with_readline = True
+            # self.options["gdbm"].with_libiconv = True
+            # if self.options.with_readline:
+            #     self.options["gdbm"].with_readline = True
 
         if self.options.with_readline:
             self.requires("readline/8.0")

--- a/conanfile.py
+++ b/conanfile.py
@@ -109,7 +109,7 @@ class OpenstudiorubyConan(ConanFile):
         not be retrieved.
         """
         self.build_requires("ruby_installer/2.5.5@bincrafters/stable")
-        self.build_requires("bison/3.5.3")
+        self.build_requires("bison_installer/3.3.2@bincrafters/stable")
 
     def build(self):
         """

--- a/conanfile.py
+++ b/conanfile.py
@@ -98,9 +98,10 @@ class OpenstudiorubyConan(ConanFile):
             self.options["gdbm"].shared = False
             # self.options["gdbm"].fPIC = True
             self.options["gdbm"].libgdbm_compat = True
-            # self.options["gdbm"].with_libiconv = True
-            # if self.options.with_readline:
-            #     self.options["gdbm"].with_readline = True
+            self.options["gdbm"].with_libiconv = True
+            self.options["gdbm"].with_nls = False
+            if self.options.with_readline:
+                self.options["gdbm"].with_readline = True
 
         if self.options.with_readline:
             self.requires("readline/8.0")

--- a/conanfile.py
+++ b/conanfile.py
@@ -122,10 +122,10 @@ class OpenstudiorubyConan(ConanFile):
         # cant use bison/3.5.3 from CCI as it uses m4 which won't build
         # with x86. So use bincrafters' still but explicitly add bin dir
         # to PATH later in CMakeLists.txt
-        # self.build_requires("bison/3.5.3")
+        self.build_requires("bison/3.5.3")
         # TODO: once https://github.com/conan-io/conan-center-index/pull/2250
         # is merged, revisit this
-        self.build_requires("bison_installer/3.3.2@bincrafters/stable")
+        # self.build_requires("bison_installer/3.3.2@bincrafters/stable")
 
     def build(self):
         """

--- a/conanfile.py
+++ b/conanfile.py
@@ -122,10 +122,12 @@ class OpenstudiorubyConan(ConanFile):
         # cant use bison/3.5.3 from CCI as it uses m4 which won't build
         # with x86. So use bincrafters' still but explicitly add bin dir
         # to PATH later in CMakeLists.txt
-        # self.build_requires("bison/3.5.3")
+        self.build_requires("bison/3.5.3")
         # TODO: once https://github.com/conan-io/conan-center-index/pull/2250
         # is merged, revisit this. Edit: PR merged but still another problem...
-        self.build_requires("bison_installer/3.3.2@bincrafters/stable")
+        # Pending https://github.com/conan-io/conan-center-index/pull/2298
+        # I'm using a special CONAN_BUILD_REQUIRES env var for win x86
+        # self.build_requires("bison_installer/3.3.2@bincrafters/stable")
 
     def build(self):
         """

--- a/conanfile.py
+++ b/conanfile.py
@@ -119,6 +119,7 @@ class OpenstudiorubyConan(ConanFile):
         not be retrieved.
         """
         self.build_requires("ruby_installer/2.5.5@bincrafters/stable")
+
         # cant use bison/3.5.3 from CCI as it uses m4 which won't build
         # with x86. So use bincrafters' still but explicitly add bin dir
         # to PATH later in CMakeLists.txt
@@ -133,7 +134,12 @@ class OpenstudiorubyConan(ConanFile):
         # if self.settings.os == "Windows" and self.settings.arch == 'x86':
         #     self.build_requires("bison_installer/3.3.2@bincrafters/stable")
         # else:
-        self.build_requires("bison/3.7.1")
+
+        # You CANNOT use bison 3.7.1 as it's stricter and will throw
+        # redefinition errors in Ruby' parser.c
+        # I had to patch bison 3.5.3 and upload it to NREL's remote to remove
+        # the YACC env variable
+        self.build_requires("bison/3.5.3")
 
     def build(self):
         """

--- a/conanfile.py
+++ b/conanfile.py
@@ -96,7 +96,7 @@ class OpenstudiorubyConan(ConanFile):
             # `conan remote update nrel https://api.bintray.com/conan/commercialbuilding/nrel --insert 0`
             self.requires("gdbm/1.18.1")
             self.options["gdbm"].shared = False
-            # self.options["gdbm"].fPIC = True
+            self.options["gdbm"].fPIC = True
             self.options["gdbm"].libgdbm_compat = True
             self.options["gdbm"].with_libiconv = False
             self.options["gdbm"].with_nls = False

--- a/conanfile.py
+++ b/conanfile.py
@@ -88,6 +88,12 @@ class OpenstudiorubyConan(ConanFile):
             # self.options["libffi"].fPIC = True
 
         if self.options.with_gdbm:
+            # NOTE: I have uploaded the gdbm/1.18.1 to the NREL remote
+            # with the status of this PR https://github.com/conan-io/conan-center-index/pull/2180
+            # at SHA https://github.com/conan-io/conan-center-index/pull/2180/commits/fad6b09ec294e8c0d186caea0c38bd6941dc0343
+            # So for now that'll only work if you have the NREL remote **before**
+            # the conan-center one...
+            # `conan remote update nrel https://api.bintray.com/conan/commercialbuilding/nrel --insert 0`
             self.requires("gdbm/1.18.1")
             self.options["gdbm"].shared = False
             # self.options["gdbm"].fPIC = True

--- a/patches/0001-patch-to-support-version-ranges-for-MSVC.patch
+++ b/patches/0001-patch-to-support-version-ranges-for-MSVC.patch
@@ -1,0 +1,25 @@
+From d6e500b878b75e8caffb661927440398464f00cd Mon Sep 17 00:00:00 2001
+From: Julien Marrec <julien.marrec@gmail.com>
+Date: Mon, 6 Apr 2020 18:02:53 +0200
+Subject: [PATCH] patch to support version ranges for MSVC
+
+---
+ win32/Makefile.sub | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/win32/Makefile.sub b/win32/Makefile.sub
+index beb0783..c8c1f53 100644
+--- a/win32/Makefile.sub
++++ b/win32/Makefile.sub
+@@ -534,7 +534,7 @@ $(CONFIG_H): $(MKFILES) $(srcdir)/win32/Makefile.sub $(win_srcdir)/Makefile.sub
+ 	@$(IFCHANGE) "--timestamp=$(@:/=\)" $(RUBY_CONFIG_H:/=\) <<
+ #ifndef $(guard)
+ #define $(guard) 1
+-#if _MSC_VER != $(MSC_VER)
++#if (($(MSC_VER) >= 1920) && (_MSC_VER < 1920)) || (($(MSC_VER) >= 1910) && ($(MSC_VER) < 1920) && !((_MSC_VER >= 1910) && (_MSC_VER < 1920))) || ((_MSC_VER < 1910) && (_MSC_VER != $(MSC_VER)))
+ #error MSC version unmatch: _MSC_VER: $(MSC_VER) is expected.
+ #endif
+ #define RUBY_MSVCRT_VERSION $(RT_VER)
+-- 
+2.21.0.windows.1
+

--- a/patches/0001-patch-to-support-version-ranges-for-MSVC.patch
+++ b/patches/0001-patch-to-support-version-ranges-for-MSVC.patch
@@ -1,25 +1,36 @@
-From d6e500b878b75e8caffb661927440398464f00cd Mon Sep 17 00:00:00 2001
+From 032db375f481313ad6295524f4f144f2aa070ab9 Mon Sep 17 00:00:00 2001
 From: Julien Marrec <julien.marrec@gmail.com>
-Date: Mon, 6 Apr 2020 18:02:53 +0200
+Date: Mon, 6 Apr 2020 18:16:40 +0200
 Subject: [PATCH] patch to support version ranges for MSVC
 
 ---
- win32/Makefile.sub | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ win32/Makefile.sub | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
 
 diff --git a/win32/Makefile.sub b/win32/Makefile.sub
-index beb0783..c8c1f53 100644
+index beb0783..56c4499 100644
 --- a/win32/Makefile.sub
 +++ b/win32/Makefile.sub
-@@ -534,7 +534,7 @@ $(CONFIG_H): $(MKFILES) $(srcdir)/win32/Makefile.sub $(win_srcdir)/Makefile.sub
+@@ -534,9 +534,19 @@ $(CONFIG_H): $(MKFILES) $(srcdir)/win32/Makefile.sub $(win_srcdir)/Makefile.sub
  	@$(IFCHANGE) "--timestamp=$(@:/=\)" $(RUBY_CONFIG_H:/=\) <<
  #ifndef $(guard)
  #define $(guard) 1
--#if _MSC_VER != $(MSC_VER)
-+#if (($(MSC_VER) >= 1920) && (_MSC_VER < 1920)) || (($(MSC_VER) >= 1910) && ($(MSC_VER) < 1920) && !((_MSC_VER >= 1910) && (_MSC_VER < 1920))) || ((_MSC_VER < 1910) && (_MSC_VER != $(MSC_VER)))
++!if $(MSC_VER) >= 1920
++#if _MSC_VER < 1920
++#error MSC version unmatch: _MSC_VER: >= 1920 is expected.
++#endif
++!else if $(MSC_VER) >= 1910
++#if _MSC_VER < 1910 || _MSC_VER >= 1920
++#error MSC version unmatch: _MSC_VER: >= 1910 and < 1920 is expected.
++#endif
++!else
+ #if _MSC_VER != $(MSC_VER)
  #error MSC version unmatch: _MSC_VER: $(MSC_VER) is expected.
  #endif
++!endif
  #define RUBY_MSVCRT_VERSION $(RT_VER)
+ #define STDC_HEADERS 1
+ #define HAVE_SYS_TYPES_H 1
 -- 
 2.21.0.windows.1
 

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -58,14 +58,24 @@ endif()
 #                               S W I G                               #
 #######################################################################
 
-# We use conan swig_installer which enhances our PATH to include the CONAN_BIN_DIRS_SWIG_INSTALLER already
-# So I could just do:
-# set(SWIG_EXECUTABLE swig)
-# But better be safe
-find_program(SWIG_EXECUTABLE swig)
-if(NOT SWIG_EXECUTABLE)
-  message(FATAL_ERROR "Couldn't find swig, which shouldn't happen. CONAN_BIN_DIRS_SWIG_INSTALLER=${CONAN_BIN_DIRS_SWIG_INSTALLER}")
-endif()
+macro(FindValue ValueName)
+  set(LocalVar "")
+  set(LocalVar $<$<CONFIG:Debug>:${${ValueName}_DEBUG}>$<$<CONFIG:Release>:${${ValueName}_RELEASE}>$<$<CONFIG:RelWithDebInfo>:${$ValueName}_RELWITHDEBINFO}>$<$<CONFIG:MinSizeRel>:${${ValueName}_MINSIZEREL}>
+  )
+#  list(JOIN LocalVar "" LocalVar)
+  string(STRIP ${LocalVar} LocalVar)
+  set(CURRENT_${ValueName} $<IF:$<BOOL:${LocalVar}>,${LocalVar},${${ValueName}}>)
+  # For debug purposes
+  # message(STATUS "Found '${ValueName}' as '${CURRENT_${ValueName}}'")
+endmacro()
+
+# So instead, we use a generator expression to find the right value. At least it makes sense, and should be robust.
+FindValue(CONAN_SWIG_ROOT)
+
+set(SWIG_EXECUTABLE "${CURRENT_CONAN_SWIG_ROOT}/bin/swig")
+
+# The conan-provided binary has a built-in swiglib (`swig -swiglib`) that points to the build box on which it was built, which is problematic for us.
+set(SWIG_LIB "${CURRENT_CONAN_SWIG_ROOT}/bin/swiglib")
 
 #######################################################################
 #                               G E M S                               #
@@ -147,14 +157,16 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR} ${PROJECT_BINARY_DIR} ${PROJECT_
 
 add_custom_command(
   OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/SWIGRubyRuntime.hxx"
-  COMMAND "${SWIG_EXECUTABLE}"
+  COMMAND ${CMAKE_COMMAND} -E env SWIG_LIB="${SWIG_LIB}"
+          "${SWIG_EXECUTABLE}"
           "-ruby"
           -external-runtime "${CMAKE_CURRENT_BINARY_DIR}/SWIGRubyRuntime.hxx"
 )
 
 add_custom_command(
   OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/embedded_scripting_wrap.cxx"
-  COMMAND "${SWIG_EXECUTABLE}"
+  COMMAND ${CMAKE_COMMAND} -E env SWIG_LIB="${SWIG_LIB}"
+          "${SWIG_EXECUTABLE}"
           "-ruby"
           "-c++"
           -o "${CMAKE_CURRENT_BINARY_DIR}/embedded_scripting_wrap.cxx"

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -21,9 +21,17 @@ class TestPackageConan(ConanFile):
         """
         Declare required dependencies for testing
         """
-        self.requires("swig/4.0.1")
         self.requires("zlib/1.2.11")
         self.options["zlib"].minizip = True
+
+    def build_requirements(self):
+        """
+        Build requirements are requirements that are only installed and used
+        when the package is built from sources. If there is an existing
+        pre-compiled binary, then the build requirements for this package will
+        not be retrieved.
+        """
+        self.requires("swig/4.0.1")
 
     def build(self):
         cmake = CMake(self)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -31,7 +31,7 @@ class TestPackageConan(ConanFile):
         pre-compiled binary, then the build requirements for this package will
         not be retrieved.
         """
-        self.build_requires("swig/4.0.1")
+        self.build_requires("swig/4.0.2")
 
     def build(self):
         cmake = CMake(self)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -23,6 +23,7 @@ class TestPackageConan(ConanFile):
         """
         self.requires("zlib/1.2.11")
         self.options["zlib"].minizip = True
+        self.requires("swig/4.0.1")
 
     def build_requirements(self):
         """
@@ -31,7 +32,7 @@ class TestPackageConan(ConanFile):
         pre-compiled binary, then the build requirements for this package will
         not be retrieved.
         """
-        self.requires("swig/4.0.1")
+        pass
 
     def build(self):
         cmake = CMake(self)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -109,6 +109,13 @@ class TestPackageConan(ConanFile):
         #     self.run("{c} -e 'puts OpenStudio::getOpenStudioCLI'".format(
         #         c=cli_path))
 
+        # Appveyor on debug is too slow to run tests under 1hr
+        # In fact, let's speed everything up and disable tests on Debug period
+        if ((self.settings.build_type == "Debug")
+            # & (self.settings.os == "Windows")
+            ):
+            return
+
         all_test_args = self._discover_tests()
         failed_tests = []
         passed_tests = []

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -21,7 +21,7 @@ class TestPackageConan(ConanFile):
         """
         Declare required dependencies for testing
         """
-        self.requires("swig_installer/4.0.0@bincrafters/stable")
+        self.requires("swig/4.0.1")
         self.requires("zlib/1.2.11")
         self.options["zlib"].minizip = True
 

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -23,7 +23,6 @@ class TestPackageConan(ConanFile):
         """
         self.requires("zlib/1.2.11")
         self.options["zlib"].minizip = True
-        self.requires("swig/4.0.1")
 
     def build_requirements(self):
         """
@@ -32,7 +31,7 @@ class TestPackageConan(ConanFile):
         pre-compiled binary, then the build requirements for this package will
         not be retrieved.
         """
-        pass
+        self.build_requires("swig/4.0.1")
 
     def build(self):
         cmake = CMake(self)

--- a/test_package/embedded/CMakeLists.txt
+++ b/test_package/embedded/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(CreateEmbeddedSource
   CreateEmbeddedSource.cpp
 )
 
-target_link_libraries(CreateEmbeddedSource CONAN_PKG::ZLIB)
+target_link_libraries(CreateEmbeddedSource CONAN_PKG::zlib)
 
 # Add a specific manifest for CreateEmbeddedSource that will include the LongPathAware attribute, which,
 # in conjunction with the regkey LongPathsEnabled=1 will make it work with paths that are longer than MAX_PATH (win10 only)

--- a/test_package/embedded/CMakeLists.txt
+++ b/test_package/embedded/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.10.2)
+
 set(CMAKE_CXX_STANDARD 11)
 
 add_executable(CreateEmbeddedSource

--- a/test_package/test/bundle/Gemfile
+++ b/test_package/test/bundle/Gemfile
@@ -1,6 +1,5 @@
 source 'http://rubygems.org'
 
-gem 'openstudio-standards', '0.2.0'
 gem 'tilt', '2.0.8'
 
 # CLI requires json_pure gem if JSON will be used

--- a/test_package/test/bundle_no_install/Gemfile
+++ b/test_package/test/bundle_no_install/Gemfile
@@ -1,4 +1,3 @@
 source 'http://rubygems.org'
 
-gem 'openstudio-standards', '0.2.2'
 gem 'tilt', '2.0.8'

--- a/test_package/test/test_bundle.rb
+++ b/test_package/test/test_bundle.rb
@@ -57,11 +57,11 @@ class Bundle_Test < Minitest::Test
 
   def test_bundle
 
+    original_dir = Dir.pwd
+
     if !system('bundle')
       skip("test_bundle requires a valid ruby 2.5.5 with 'bundle' gem installed")
     end
-
-    original_dir = Dir.pwd
 
     test_folder = prepare_test_folder('bundle')
     Dir.chdir(test_folder)
@@ -81,11 +81,12 @@ class Bundle_Test < Minitest::Test
   end
 
   def test_bundle_git
+
+    original_dir = Dir.pwd
+
     if !system('bundle')
       skip("test_bundle_git requires a valid ruby 2.5.5 with 'bundle' gem installed")
     end
-
-    original_dir = Dir.pwd
 
     test_folder = prepare_test_folder('bundle_git')
     Dir.chdir(test_folder)

--- a/test_package/test/test_bundle.rb
+++ b/test_package/test/test_bundle.rb
@@ -56,6 +56,11 @@ class Bundle_Test < Minitest::Test
   end
 
   def test_bundle
+
+    if !system('bundle')
+      skip("test_bundle requires a valid ruby 2.5.5 with 'bundle' gem installed")
+    end
+
     original_dir = Dir.pwd
 
     test_folder = prepare_test_folder('bundle')
@@ -76,6 +81,10 @@ class Bundle_Test < Minitest::Test
   end
 
   def test_bundle_git
+    if !system('bundle')
+      skip("test_bundle_git requires a valid ruby 2.5.5 with 'bundle' gem installed")
+    end
+
     original_dir = Dir.pwd
 
     test_folder = prepare_test_folder('bundle_git')


### PR DESCRIPTION
Fix #26 - patch MSVC ranges
Fix #25 - revert ruby installers to bincrafters/stable