### PR TITLE
enable option --enable-load-relative

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,7 @@ if( UNIX )
   # brew install autoconf automake libtool
   # brew link autoconf automake libtool
 
-  set(configure_cmd "./configure --with-static-linked-ext ${MAC_opts} --disable-install-doc --prefix=${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install ${CONF_ARGS}")
+  set(configure_cmd "./configure --with-static-linked-ext --enable-load-relative ${MAC_opts} --disable-install-doc --prefix=${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install ${CONF_ARGS}")
   ExternalProject_Add(Ruby
     # Use official ruby source package to reduce dependencies on autoconf and friends
     URL https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.gz

--- a/build_ruby.bat.in
+++ b/build_ruby.bat.in
@@ -69,7 +69,7 @@ echo "CONF_ARGS='%CONF_ARGS%'"
 
 @ECHO ON
 
-call ${CMAKE_BINARY_DIR}\Ruby-prefix\src\Ruby\win32\configure.bat --disable-install-doc --with-static-linked-ext --without-ext=+,dbm,gdbm --enable-bundled-libffi %CONF_ARGS% --prefix="${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/" --with-baseruby="%BASE_RUBY%" 
+call ${CMAKE_BINARY_DIR}\Ruby-prefix\src\Ruby\win32\configure.bat --disable-install-doc ---enable-load-relative  -with-static-linked-ext --without-ext=+,dbm,gdbm --enable-bundled-libffi %CONF_ARGS% --prefix="${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/" --with-baseruby="%BASE_RUBY%" 
 
 
 nmake incs

--- a/build_ruby.bat.in
+++ b/build_ruby.bat.in
@@ -69,7 +69,7 @@ echo "CONF_ARGS='%CONF_ARGS%'"
 
 @ECHO ON
 
-call ${CMAKE_BINARY_DIR}\Ruby-prefix\src\Ruby\win32\configure.bat --disable-install-doc ---enable-load-relative  -with-static-linked-ext --without-ext=+,dbm,gdbm --enable-bundled-libffi %CONF_ARGS% --prefix="${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/" --with-baseruby="%BASE_RUBY%" 
+call ${CMAKE_BINARY_DIR}\Ruby-prefix\src\Ruby\win32\configure.bat --disable-install-doc --enable-load-relative  --with-static-linked-ext --without-ext=+,dbm,gdbm --enable-bundled-libffi %CONF_ARGS% --prefix="${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/" --with-baseruby="%BASE_RUBY%" 
 
 
 nmake incs


### PR DESCRIPTION
I think we need to enable this flag -`-enable-load-relative` when configuring ruby.  The bin stubs do not have hard-coded links when this is enabled. 

For instance, if you look at the ruby/bin/gem 

```
ruby/bin/gem

#!/home/ubuntu/.conan/data/openstudio_ruby/2.7.2/nrel/testing/build/9f9bc9c7ba86f123c671ad0cd57bd027161f8634/Ruby-prefix/src/Ruby-install/bin/ruby
#--
# Copyright 2006 by Chad Fowler, Rich Kilmer, Jim Weirich and others.
# All rights reserved.
# See LICENSE.txt for permissions.
#++

require 'rubygems'
require 'rubygems/gem_runner'
require 'rubygems/exceptions'
```

vs enable-load-relative

```
#!/bin/sh
# -*- ruby -*-
_=_\
=begin
bindir="${0%/*}"
exec "$bindir/ruby" "-x" "$0" "$@"
=end
#!/usr/bin/env ruby
#--
# Copyright 2006 by Chad Fowler, Rich Kilmer, Jim Weirich and others.
# All rights reserved.
# See LICENSE.txt for permissions.
#++

require 'rubygems'
require 'rubygems/gem_runner'
require 'rubygems/exceptions'
```

This might explain why I get this error when installing openstudio on a clean image. 

Steps to reproduce: 

- Install on Ubuntu 18.04: https://openstudio-ci-builds.s3-us-west-2.amazonaws.com/ruby-270/OpenStudio-3.1.1-alpha%2B7ebeff9fc8-Linux.deb

- Install Ruby 2.7.2 (currently have to compile or try snap)

- Create a simple Gemfile

```
source 'http://rubygems.org'
ruby "~> 2.7.0"

gem 'parallel', '1.19.1'
```

- Create the bundle package 

`bundle _2.1.4_ install --path=gems `

- run bundle with openstudio cli 

`openstudio --verbose --bundle ./Gemfile --bundle_path ./gems --bundle_without native_ext  openstudio_version`

Or you can pull down a pre-built image with all the above. 

`docker pull tijcolem/openstudio-ruby272-test`


`docker exec -it <image-instance-id> bash`


```
openstudio --verbose --bundle /var/oscli/Gemfile --bundle_path /var/oscli/gems --bundle_without native_ext  openstudio_version
```

 
This is the error.  OpenStudo CLI is using bundler 2.1.4 

```
openstudio --verbose --bundle /var/oscli/Gemfile --bundle_path /var/oscli/gems --bundle_without native_ext  openstudio_version
I, [2021-02-10T00:48:28.280827 #75]  INFO -- : CLI Parsed Inputs: ["--verbose", "--bundle", "/var/oscli/Gemfile", "--bundle_path", "/var/oscli/gems", "--bundle_without", "native_ext"] "openstudio_version" []
D, [2021-02-10T00:48:28.280898 #75] DEBUG -- : Main arguments are ["--verbose", "--bundle", "/var/oscli/Gemfile", "--bundle_path", "/var/oscli/gems", "--bundle_without", "native_ext"]
D, [2021-02-10T00:48:28.280925 #75] DEBUG -- : Sub-command is openstudio_version
D, [2021-02-10T00:48:28.280942 #75] DEBUG -- : Sub-arguments are []
D, [2021-02-10T00:48:28.280968 #75] DEBUG -- : Parsing main_args ["--verbose", "--bundle", "/var/oscli/Gemfile", "--bundle_path", "/var/oscli/gems", "--bundle_without", "native_ext"]
I, [2021-02-10T00:48:28.280994 #75]  INFO -- : Setting BUNDLE_GEMFILE to /var/oscli/Gemfile
I, [2021-02-10T00:48:28.281024 #75]  INFO -- : Setting BUNDLE_PATH to /var/oscli/gems
I, [2021-02-10T00:48:28.281073 #75]  INFO -- : Setting BUNDLE_WITHOUT to native_ext
D, [2021-02-10T00:48:28.809687 #75] DEBUG -- : Adding dependency on openstudio-extension '~> 0.4.0'
D, [2021-02-10T00:48:28.809768 #75] DEBUG -- : Adding dependency on openstudio_measure_tester '~> 0.3.0'
D, [2021-02-10T00:48:28.809823 #75] DEBUG -- : Adding dependency on openstudio-workflow '~> 2.2.0'
D, [2021-02-10T00:48:28.809860 #75] DEBUG -- : Adding dependency on bcl '~> 0.7.0'
D, [2021-02-10T00:48:28.809893 #75] DEBUG -- : Adding dependency on jaro_winkler '~> 1.5.4'
D, [2021-02-10T00:48:28.809925 #75] DEBUG -- : Adding dependency on pycall '~> 1.2.1'
D, [2021-02-10T00:48:28.809954 #75] DEBUG -- : Adding dependency on sqlite3 '~> 1.3.13.20180326210955'
D, [2021-02-10T00:48:28.809986 #75] DEBUG -- : Adding dependency on addressable '~> 2.7.0'
D, [2021-02-10T00:48:28.810016 #75] DEBUG -- : Adding dependency on ansi '~> 1.5.0'
D, [2021-02-10T00:48:28.810041 #75] DEBUG -- : Adding dependency on ast '~> 2.4.2'
D, [2021-02-10T00:48:28.810072 #75] DEBUG -- : Adding dependency on builder '~> 3.2.4'
D, [2021-02-10T00:48:28.810093 #75] DEBUG -- : Adding dependency on bundler '~> 2.1.4'
D, [2021-02-10T00:48:28.810133 #75] DEBUG -- : Adding dependency on docile '~> 1.3.5'
D, [2021-02-10T00:48:28.810157 #75] DEBUG -- : Adding dependency on faraday '~> 1.0.1'
D, [2021-02-10T00:48:28.810186 #75] DEBUG -- : Adding dependency on git '~> 1.6.0'
D, [2021-02-10T00:48:28.810215 #75] DEBUG -- : Adding dependency on macaddr '~> 1.7.2'
D, [2021-02-10T00:48:28.810243 #75] DEBUG -- : Adding dependency on minitar '~> 0.9'
D, [2021-02-10T00:48:28.810265 #75] DEBUG -- : Adding dependency on minitest '~> 5.14.3'
D, [2021-02-10T00:48:28.810287 #75] DEBUG -- : Adding dependency on minitest-reporters '~> 1.4.3'
D, [2021-02-10T00:48:28.810317 #75] DEBUG -- : Adding dependency on multipart-post '~> 2.1.1'
D, [2021-02-10T00:48:28.810346 #75] DEBUG -- : Adding dependency on octokit '~> 4.18.0'
D, [2021-02-10T00:48:28.810376 #75] DEBUG -- : Adding dependency on oga '~> 3.2'
D, [2021-02-10T00:48:28.810405 #75] DEBUG -- : Adding dependency on parallel '~> 1.19.1'
D, [2021-02-10T00:48:28.810429 #75] DEBUG -- : Adding dependency on parser '~> 3.0.0.0'
D, [2021-02-10T00:48:28.810474 #75] DEBUG -- : Adding dependency on powerpack '~> 0.1.3'
D, [2021-02-10T00:48:28.810510 #75] DEBUG -- : Adding dependency on public_suffix '~> 4.0.6'
D, [2021-02-10T00:48:28.810536 #75] DEBUG -- : Adding dependency on rainbow '~> 3.0.0'
D, [2021-02-10T00:48:28.810563 #75] DEBUG -- : Adding dependency on rake '~> 13.0.3'
D, [2021-02-10T00:48:28.810593 #75] DEBUG -- : Adding dependency on rchardet '~> 1.8.0'
D, [2021-02-10T00:48:28.810622 #75] DEBUG -- : Adding dependency on rexml '~> 3.2.4'
D, [2021-02-10T00:48:28.810651 #75] DEBUG -- : Adding dependency on rubocop '~> 0.54.0'
D, [2021-02-10T00:48:28.810674 #75] DEBUG -- : Adding dependency on rubocop-checkstyle_formatter '~> 0.4.0'
D, [2021-02-10T00:48:28.810703 #75] DEBUG -- : Adding dependency on ruby-ll '~> 2.1.2'
D, [2021-02-10T00:48:28.810731 #75] DEBUG -- : Adding dependency on ruby-ole '~> 1.2.12.2'
D, [2021-02-10T00:48:28.810762 #75] DEBUG -- : Adding dependency on ruby-progressbar '~> 1.11.0'
D, [2021-02-10T00:48:28.810791 #75] DEBUG -- : Adding dependency on rubyzip '~> 2.3.0'
D, [2021-02-10T00:48:28.810847 #75] DEBUG -- : Adding dependency on sawyer '~> 0.8.2'
D, [2021-02-10T00:48:28.810871 #75] DEBUG -- : Adding dependency on simplecov '~> 0.18.5'
D, [2021-02-10T00:48:28.810900 #75] DEBUG -- : Adding dependency on simplecov-html '~> 0.12.3'
D, [2021-02-10T00:48:28.810928 #75] DEBUG -- : Adding dependency on spreadsheet '~> 1.2.6'
D, [2021-02-10T00:48:28.810958 #75] DEBUG -- : Adding dependency on systemu '~> 2.6.5'
D, [2021-02-10T00:48:28.810987 #75] DEBUG -- : Adding dependency on unicode-display_width '~> 1.7.0'
D, [2021-02-10T00:48:28.811020 #75] DEBUG -- : Adding dependency on uuid '~> 2.3.9'
D, [2021-02-10T00:48:28.811044 #75] DEBUG -- : Adding dependency on yamler '~> 0.1.0'
D, [2021-02-10T00:48:28.811067 #75] DEBUG -- : Adding dependency on zliby '~> 0.0.5'
D, [2021-02-10T00:48:28.843352 #75] DEBUG -- : Processing 45 activation requests
I, [2021-02-10T00:48:31.990775 #75]  INFO -- : without_groups = native_ext
I, [2021-02-10T00:48:31.990830 #75]  INFO -- : g = default
I, [2021-02-10T00:48:31.990855 #75]  INFO -- : g = development
I, [2021-02-10T00:48:31.990873 #75]  INFO -- : g = native_ext
I, [2021-02-10T00:48:31.990889 #75]  INFO -- : Bundling without group 'native_ext'
I, [2021-02-10T00:48:31.990908 #75]  INFO -- : Bundling with groups [default,development]
I, [2021-02-10T00:48:32.111401 #75]  INFO -- : Specs to be included [rake,public_suffix,addressable,ansi,ast,builder,multipart-post,faraday,minitar,rchardet,git,minitest,ruby-progressbar,minitest-reporters,parallel,parser,powerpack,rainbow,unicode-display_width,rubocop,rubocop-checkstyle_formatter,docile,simplecov-html,simplecov,openstudio_measure_tester,rexml,rubyzip,ruby-ole,spreadsheet,systemu,macaddr,uuid,yamler,zliby,bcl,bundler,sawyer,octokit,openstudio-workflow,openstudio-extension,openstudio-gems]
Error executing argv: ["--verbose", "--bundle", "/var/oscli/Gemfile", "--bundle_path", "/var/oscli/gems", "--bundle_without", "native_ext", "openstudio_version"]
Error: Could not find 'bundler' (2.1.4) required by your /var/oscli/Gemfile.lock.
To update to the latest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:2.1.4`
 in :/ruby/2.7.0/rubygems.rb:277:in `find_spec_for_exe'
:/ruby/2.7.0/rubygems.rb:254:in `bin_path'
:/ruby/2.7.0/bundler/rubygems_integration.rb:223:in `bin_path'
:/ruby/2.7.0/bundler/shared_helpers.rb:297:in `set_bundle_variables'
:/ruby/2.7.0/bundler/shared_helpers.rb:76:in `set_bundle_environment'
:/ruby/2.7.0/bundler/runtime.rb:22:in `setup'
:/ruby/2.7.0/bundler.rb:257:in `setup'
:/openstudio_cli.rb:615:in `parse_main_args'
:/openstudio_cli.rb:739:in `execute'
:/openstudio_cli.rb:1769:in `<main>'
eval:177:in `eval'
eval:177:in `require_embedded_absolute'
eval:162:in `block in require_embedded'
eval:156:in `each'
eval:156:in `require_embedded'
eval:115:in `require'
eval:3:in `<main>'
root@61b7521aff1c:/var/simdata/openstudio# 
```













