### PR TITLE
Support CP720: backport a ruby 3.0 fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,7 +226,7 @@ if( UNIX )
     URL_HASH SHA256=6e5706d0d4ee4e1e2f883db9d768586b4d06567debea353c796ec45e8321c3d4
 
     # The 'nodynamic' modules patch fails to build in any way on Unix, with 2.5.x, so we aren't using it (at the moment anyhow)
-    PATCH_COMMAND pwd && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.patch && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.util.patch # && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.nodynamic.patch
+    PATCH_COMMAND pwd && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.patch && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.util.patch && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/0002-patch-encoding-CP720.patch# && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.nodynamic.patch
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND pwd && sh -c "pwd && echo '===============  CONFIGURE ============' && echo 'Calling: ${configure_cmd}' && ${configure_cmd}"
     #    BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} Use default BUILD_COMMAND for now
@@ -292,9 +292,13 @@ else()
     URL https://codeload.github.com/ruby/ruby/tar.gz/v2_7_2
     URL_HASH SHA256=60986e07bbf1d69f547951dfb76ac4cdee6128a26f235f7501080cc308d30c9f
 
-    PATCH_COMMAND ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.patch && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.win.patch && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.win.CCI.patch && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.win.272.patch  # && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.nodynamic.patch
-                  && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/0001-patch-to-support-version-ranges-for-MSVC.patch
-                  && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.util.patch
+    PATCH_COMMAND ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.patch
+               && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.win.patch
+               && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.win.CCI.patch
+               && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.win.272.patch  # && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.nodynamic.patch
+               && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/0001-patch-to-support-version-ranges-for-MSVC.patch
+               && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/0002-patch-encoding-CP720.patch
+               && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.util.patch
     CONFIGURE_COMMAND ""
     BUILD_COMMAND cmd /C "${CMAKE_BINARY_DIR}/build_ruby_$<CONFIG>.bat"
     INSTALL_COMMAND "" # ${CMAKE_COMMAND} -E copy "${CMAKE_BINARY_DIR}/FFI-prefix/src/FFI-install/$<CONFIG>/lib/libffi.lib" "${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install/lib/"

--- a/patches/0002-patch-encoding-CP720.patch
+++ b/patches/0002-patch-encoding-CP720.patch
@@ -11,3 +11,158 @@ index 8b32c414fe..a2fef2f879 100644
  ENC_REPLICATE("IBM737", "ASCII-8BIT")
  ENC_ALIAS("CP737", "IBM737")
  ENC_REPLICATE("IBM775", "ASCII-8BIT")
+diff --git a/enc/trans/single_byte.trans b/enc/trans/single_byte.trans
+index cf521bed38..0d5407b918 100644
+--- a/enc/trans/single_byte.trans
++++ b/enc/trans/single_byte.trans
+@@ -51,8 +51,9 @@
+   transcode_tblgen_singlebyte "WINDOWS-1256"
+   transcode_tblgen_singlebyte "WINDOWS-1257"
+   transcode_tblgen_singlebyte "IBM437"
+-  transcode_tblgen_singlebyte "IBM775"
++  transcode_tblgen_singlebyte "IBM720"
+   transcode_tblgen_singlebyte "IBM737"
++  transcode_tblgen_singlebyte "IBM775"
+   transcode_tblgen_singlebyte "IBM852"
+   transcode_tblgen_singlebyte "IBM855"
+   transcode_tblgen_singlebyte "IBM857"
+diff --git a/ext/win32ole/win32ole.c b/ext/win32ole/win32ole.c
+index 4f4550c5b9..59bae0e774 100644
+--- a/ext/win32ole/win32ole.c
++++ b/ext/win32ole/win32ole.c
+@@ -507,6 +507,7 @@ static UINT ole_encoding2cp(rb_encoding *enc)
+     ENC_MACHING_CP(enc, "GB2312", 20936);
+     ENC_MACHING_CP(enc, "GBK", 936);
+     ENC_MACHING_CP(enc, "IBM437", 437);
++    ENC_MACHING_CP(enc, "IBM720", 720);
+     ENC_MACHING_CP(enc, "IBM737", 737);
+     ENC_MACHING_CP(enc, "IBM775", 775);
+     ENC_MACHING_CP(enc, "IBM852", 852);
+diff --git a/enc/trans/ibm720-tbl.rb b/enc/trans/ibm720-tbl.rb
+new file mode 100644
+index 0000000000..558684d649
+--- /dev/null
++++ b/enc/trans/ibm720-tbl.rb
+@@ -0,0 +1,122 @@
++IBM720_TO_UCS_TBL = [
++  ["FF",0xA0],
++  ["9C",0xA3],
++  ["94",0xA4],
++  ["AE",0xAB],
++  ["F8",0xB0],
++  ["FD",0xB2],
++  ["E6",0xB5],
++  ["FA",0xB7],
++  ["AF",0xBB],
++  ["85",0xE0],
++  ["83",0xE2],
++  ["87",0xE7],
++  ["8A",0xE8],
++  ["82",0xE9],
++  ["88",0xEA],
++  ["89",0xEB],
++  ["8C",0xEE],
++  ["8B",0xEF],
++  ["93",0xF4],
++  ["97",0xF9],
++  ["96",0xFB],
++  ["98",0x621],
++  ["99",0x622],
++  ["9A",0x623],
++  ["9B",0x624],
++  ["9D",0x625],
++  ["9E",0x626],
++  ["9F",0x627],
++  ["A0",0x628],
++  ["A1",0x629],
++  ["A2",0x62A],
++  ["A3",0x62B],
++  ["A4",0x62C],
++  ["A5",0x62D],
++  ["A6",0x62E],
++  ["A7",0x62F],
++  ["A8",0x630],
++  ["A9",0x631],
++  ["AA",0x632],
++  ["AB",0x633],
++  ["AC",0x634],
++  ["AD",0x635],
++  ["E0",0x636],
++  ["E1",0x637],
++  ["E2",0x638],
++  ["E3",0x639],
++  ["E4",0x63A],
++  ["95",0x640],
++  ["E5",0x641],
++  ["E7",0x642],
++  ["E8",0x643],
++  ["E9",0x644],
++  ["EA",0x645],
++  ["EB",0x646],
++  ["EC",0x647],
++  ["ED",0x648],
++  ["EE",0x649],
++  ["EF",0x64A],
++  ["F1",0x64B],
++  ["F2",0x64C],
++  ["F3",0x64D],
++  ["F4",0x64E],
++  ["F5",0x64F],
++  ["F6",0x650],
++  ["91",0x651],
++  ["92",0x652],
++  ["FC",0x207F],
++  ["F9",0x2219],
++  ["FB",0x221A],
++  ["F7",0x2248],
++  ["F0",0x2261],
++  ["C4",0x2500],
++  ["B3",0x2502],
++  ["DA",0x250C],
++  ["BF",0x2510],
++  ["C0",0x2514],
++  ["D9",0x2518],
++  ["C3",0x251C],
++  ["B4",0x2524],
++  ["C2",0x252C],
++  ["C1",0x2534],
++  ["C5",0x253C],
++  ["CD",0x2550],
++  ["BA",0x2551],
++  ["D5",0x2552],
++  ["D6",0x2553],
++  ["C9",0x2554],
++  ["B8",0x2555],
++  ["B7",0x2556],
++  ["BB",0x2557],
++  ["D4",0x2558],
++  ["D3",0x2559],
++  ["C8",0x255A],
++  ["BE",0x255B],
++  ["BD",0x255C],
++  ["BC",0x255D],
++  ["C6",0x255E],
++  ["C7",0x255F],
++  ["CC",0x2560],
++  ["B5",0x2561],
++  ["B6",0x2562],
++  ["B9",0x2563],
++  ["D1",0x2564],
++  ["D2",0x2565],
++  ["CB",0x2566],
++  ["CF",0x2567],
++  ["D0",0x2568],
++  ["CA",0x2569],
++  ["D8",0x256A],
++  ["D7",0x256B],
++  ["CE",0x256C],
++  ["DF",0x2580],
++  ["DC",0x2584],
++  ["DB",0x2588],
++  ["DD",0x258C],
++  ["DE",0x2590],
++  ["B0",0x2591],
++  ["B1",0x2592],
++  ["B2",0x2593],
++  ["FE",0x25A0],
++]

--- a/patches/0002-patch-encoding-CP720.patch
+++ b/patches/0002-patch-encoding-CP720.patch
@@ -1,0 +1,13 @@
+diff --git a/enc/ascii.c b/enc/ascii.c
+index 8b32c414fe..a2fef2f879 100644
+--- a/enc/ascii.c
++++ b/enc/ascii.c
+@@ -61,6 +61,8 @@ OnigEncodingDefine(ascii, ASCII) = {
+ ENC_ALIAS("BINARY", "ASCII-8BIT")
+ ENC_REPLICATE("IBM437", "ASCII-8BIT")
+ ENC_ALIAS("CP437", "IBM437")
++ENC_REPLICATE("IBM720", "ASCII-8BIT")
++ENC_ALIAS("CP720", "IBM720")
+ ENC_REPLICATE("IBM737", "ASCII-8BIT")
+ ENC_ALIAS("CP737", "IBM737")
+ ENC_REPLICATE("IBM775", "ASCII-8BIT")


### PR DESCRIPTION
The last two commits are optional... they fix https://github.com/NREL/OpenStudio/issues/4397 by backporting a Ruby 3.0 fix to ruby 2.7.2

Edit: I put the clean up portion in #37 , and kept the CP720 only on this PR by rebasing onto master after merging