### PR TITLE
Centos changes

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -125,10 +125,7 @@ class OpenstudiorubyConan(ConanFile):
         pre-compiled binary, then the build requirements for this package will
         not be retrieved.
         """
-        if tools.os_info.linux_distro in ["centos"]:
-            self.build_requires("ruby_installer/2.7.3@nrel/centos")
-        else:
-            self.build_requires("ruby_installer/2.7.3@bincrafters/stable")
+        self.build_requires("ruby_installer/2.7.3@bincrafters/stable")
 
         # cant use bison/3.5.3 from CCI as it uses m4 which won't build
         # with x86. So use bincrafters' still but explicitly add bin dir

--- a/conanfile.py
+++ b/conanfile.py
@@ -64,12 +64,13 @@ class OpenstudiorubyConan(ConanFile):
         # I could let it slide, and hope for the best, but I'm afraid of other
         # incompatibilities, so just raise (which shouldn't happen when trying
         # to install from OpenStudio's cmake)
-        if (self.settings.compiler == 'gcc'):
-            if (self.settings.compiler.libcxx != "libstdc++11"):
-                msg = ("This isn't meant to be compiled with an old "
-                       " GCC ABI (though complation will work), "
-                       "please use settings.compiler.libcxx=libstdc++11")
-                raise ConanInvalidConfiguration(msg)
+        if tools.os_info.linux_distro not in ["centos"]:
+            if (self.settings.compiler == 'gcc'):
+                if (self.settings.compiler.libcxx != "libstdc++11"):
+                    msg = ("This isn't meant to be compiled with an old "
+                           " GCC ABI (though complation will work), "
+                           "please use settings.compiler.libcxx=libstdc++11")
+                    raise ConanInvalidConfiguration(msg)
 
         # I delete the libcxx setting now, so that the package_id isn't
         # calculated taking this into account.

--- a/conanfile.py
+++ b/conanfile.py
@@ -86,7 +86,7 @@ class OpenstudiorubyConan(ConanFile):
         """
         self.requires("openssl/1.1.0l") # fails with 1.1.1h https://github.com/openssl/openssl/issues/3884`
         # Make sure you get a zlib post separation between zlib and minizip
-        self.requires("zlib/1.2.11#683857dbd5377d65f26795d4023858f9")
+        self.requires("zlib/1.2.12")
 
         if self.options.with_libyaml:
             self.requires("libyaml/0.2.5")
@@ -163,7 +163,13 @@ class OpenstudiorubyConan(ConanFile):
         # for patch in self.conan_data["patches"][self.version]:
         #     tools.patch(**patch)
 
-        cmake = CMake(self)
+        parallel = True
+        if tools.os_info.linux_distro in ["centos"]:
+            # parallel=False required or MFLAGS = -s --jobserver-fds=3,4 -j
+            # is strapped and centos' make is too old to understand
+            parallel = False
+
+        cmake = CMake(self, parallel=parallel)
         cmake.definitions["INTEGRATED_CONAN"] = False
         cmake.configure()
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -125,7 +125,7 @@ class OpenstudiorubyConan(ConanFile):
         pre-compiled binary, then the build requirements for this package will
         not be retrieved.
         """
-        self.build_requires("ruby_installer/2.7.3@bincrafters/stable")
+        self.build_requires("ruby_installer/2.7.3@nrel/stable")
 
         # cant use bison/3.5.3 from CCI as it uses m4 which won't build
         # with x86. So use bincrafters' still but explicitly add bin dir

--- a/conanfile.py
+++ b/conanfile.py
@@ -152,7 +152,7 @@ class OpenstudiorubyConan(ConanFile):
         # Latest bison with m4/1.4.18
         # self.build_requires("bison/3.7.1#dcffa3dd9204cb79ac7ca09a7f19bb8b")
         # The one on NREL (older)
-        self.build_requires("bison/3.7.1#ad29e804e82c8b6d58765096676b5a5e")
+        self.build_requires("bison/3.7.1")
 
     def build(self):
         """

--- a/conanfile.py
+++ b/conanfile.py
@@ -130,7 +130,10 @@ class OpenstudiorubyConan(ConanFile):
         pre-compiled binary, then the build requirements for this package will
         not be retrieved.
         """
-        self.build_requires("ruby_installer/2.7.3@bincrafters/stable")
+        if tools.os_info.linux_distro in ["centos"]:
+            self.build_requires("ruby_installer/2.7.3@nrel/centos")
+        else:
+            self.build_requires("ruby_installer/2.7.3@bincrafters/stable")
 
         # cant use bison/3.5.3 from CCI as it uses m4 which won't build
         # with x86. So use bincrafters' still but explicitly add bin dir

--- a/conanfile.py
+++ b/conanfile.py
@@ -152,7 +152,7 @@ class OpenstudiorubyConan(ConanFile):
         # Latest bison with m4/1.4.18
         # self.build_requires("bison/3.7.1#dcffa3dd9204cb79ac7ca09a7f19bb8b")
         # The one on NREL (older)
-        self.build_requires("bison/3.7.1#8bba3cd5416cf47dbc99130108ecb67e")
+        self.build_requires("bison/3.7.1#ad29e804e82c8b6d58765096676b5a5e")
 
     def build(self):
         """

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -21,7 +21,7 @@ class TestPackageConan(ConanFile):
         """
         Declare required dependencies for testing
         """
-        self.requires("minizip/1.2.11")  # depends on zlib/1.2.11
+        self.requires("minizip/1.2.12")  # depends on zlib/1.2.12
 
     def build_requirements(self):
         """


### PR DESCRIPTION
- Remove forcing libstdc++11 for centos (which doens't have it)
- Build not in parallel (doesn't work in parallel)
- Use my patched ruby_installer for all platforms: https://github.com/jmarrec/conan-ruby_installer/