### PR TITLE
Fix older machines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,23 +128,23 @@ jobs:
           set -x
 
           echo "=========== MAKEFILE ================"
-          find ~/.conan/data/openstudio_ruby/2.7.2/nrel/testing/build -name "Makefile"|while read fname; do
+          find ~/.conan/data/openstudio_ruby/2.7.2/$CONAN_USERNAME/testing/build -name "Makefile"|while read fname; do
             echo "============== $fname ============"
             cat $fname
             echo ""
             echo ""
             echo ""
-          done
+          done || true
 
           #if [[ "$(uname -s)" == 'Darwin' ]]; then
           echo "=========== RUBY MKMF.LOG ================"
-          find ~/.conan/data/openstudio_ruby/2.7.2/nrel/testing/build -name "mkmf.log"|while read fname; do
+          find ~/.conan/data/openstudio_ruby/2.7.2/$CONAN_USERNAME/testing/build -name "mkmf.log"|while read fname; do
             echo "============== $fname ============"
             cat $fname
             echo ""
             echo ""
             echo ""
-          done
+          done || true
 
           #echo "======== LISTING THE GDBM LIB FOLDERS ========"
           #find ~/.conan/data/gdbm/1.18.1/_/_/package/ -name 'lib' -type 'd'|while read dirname; do
@@ -153,7 +153,7 @@ jobs:
           #  echo ""
           #  echo ""
           #  echo ""
-          #done
+          #done || true
 
           #echo "======== LISTING THE GDBM INCLUDE FOLDERS ========"
           #find ~/.conan/data/gdbm/1.18.1/_/_/package/ -name 'include' -type 'd'|while read dirname; do
@@ -162,22 +162,22 @@ jobs:
           #  echo ""
           #  echo ""
           #  echo ""
-          #done
+          #done || true
 
           echo "=========== RUBY CONFIG.LOG ================"
-          find ~/.conan/data/openstudio_ruby/2.7.2/nrel/testing/build -name "config.log"|while read fname; do
+          find ~/.conan/data/openstudio_ruby/2.7.2/$CONAN_USERNAME/testing/build -name "config.log"|while read fname; do
             echo "============== $fname ============"
             cat $fname
             echo ""
             echo ""
             echo ""
-          done
+          done || true
 
           echo "=========== RUBY CONFIG.STATUS ================"
-          find ~/.conan/data/openstudio_ruby/2.7.2/nrel/testing/build -name "config.status"|while read fname; do
+          find ~/.conan/data/openstudio_ruby/2.7.2/$CONAN_USERNAME/testing/build -name "config.status"|while read fname; do
             echo "============== $fname ============"
             cat $fname
             echo ""
             echo ""
             echo ""
-          done
+          done || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,13 +87,6 @@ jobs:
           conan config set general.revisions_enabled=True
           conan config set general.parallel_download=8
 
-          if [[ "${{ matrix.build_name }}" == 'Apple-Clang 12' ]]; then
-            echo "CONAN_ARCHS=x86_64,armv8" >> $GITHUB_ENV
-          else
-            # No need for x86
-            echo "CONAN_ARCHS=x86_64" >> $GITHUB_ENV
-          fi
-
           # Use lowercase based on repository owner, so that NREL -> nrel.
           # That should work on forks, while not replacing 'nrel' with '***' everywhere like it does when you set CONAN_USERNAME as a repo secret...
           # We want BPT/CPT to produces openstudio_ruby/2.7.2@<CONAN_USERNAME>/<channel>
@@ -111,6 +104,7 @@ jobs:
           CONAN_STABLE_BRANCH_PATTERN: master
           CONAN_CHANNEL: testing
           CONAN_REMOTES: "https://conan.openstudio.net/artifactory/api/conan/openstudio@True@nrel,https://bincrafters.jfrog.io/artifactory/api/conan/public-conan@True@bincrafters"
+          CONAN_ARCHS: x86_64   # No need for x86
           CONAN_VISUAL_RUNTIMES: MD,MDd   # Ignoring MT and MTd
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,8 +116,8 @@ jobs:
           CONAN_REMOTES: "https://conan.openstudio.net/artifactory/api/conan/openstudio@True@nrel,https://bincrafters.jfrog.io/artifactory/api/conan/public-conan@True@bincrafters"
           CONAN_ARCHS: x86_64   # No need for x86
           CONAN_VISUAL_RUNTIMES: MD,MDd   # Ignoring MT and MTd
+        shell: bash
         run: |
-          conan remote add --insert 0 -f nrel https://conan.commercialbuildings.dev/artifactory/api/conan/openstudio
           bincrafters-package-tools --auto
 
       - name: Debug

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       # fail-fast: Default is true, switch to false to allow one platform to fail and still run others
       fail-fast: false
       matrix:
-        build_name: [GCC-7, GCC-8, GCC-9, GCC-10, GCC-11, Apple-Clang 11, Apple-Clang 12, MSVC-2022, MSVC-2019, MSVC-2017]
+        build_name: [GCC-7, GCC-8, GCC-9, GCC-10, GCC-11, Apple-Clang 11, Apple-Clang 12, MSVC-2022, MSVC-2019]
         include:
         - build_name: GCC-7
           os: ubuntu-18.04
@@ -66,11 +66,6 @@ jobs:
           os: windows-2019
           compiler: VISUAL
           version: 16
-          allow_failure: false
-        - build_name: MSVC-2017
-          os: windows-2016
-          compiler: VISUAL
-          version: 15
           allow_failure: false
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,9 +87,11 @@ jobs:
           conan config set general.revisions_enabled=True
           conan config set general.parallel_download=8
 
-          if [[ "${{ matrix.build_name }}" == 'MSVC-2017' ]]; then
-            # For some reason, it's picking up ml.exe (x86) and fails to assemble coroutine\Context.asm
-            echo "AS=ml64 -nologo" >> $GITHUB_ENV
+          if [[ "${{ matrix.build_name }}" == 'Apple-Clang 12' ]]; then
+            echo "CONAN_ARCHS=x86_64,armv8" >> $GITHUB_ENV
+          else
+            # No need for x86
+            echo "CONAN_ARCHS=x86_64" >> $GITHUB_ENV
           fi
 
           # Use lowercase based on repository owner, so that NREL -> nrel.
@@ -109,7 +111,6 @@ jobs:
           CONAN_STABLE_BRANCH_PATTERN: master
           CONAN_CHANNEL: testing
           CONAN_REMOTES: "https://conan.openstudio.net/artifactory/api/conan/openstudio@True@nrel,https://bincrafters.jfrog.io/artifactory/api/conan/public-conan@True@bincrafters"
-          CONAN_ARCHS: x86_64   # No need for x86
           CONAN_VISUAL_RUNTIMES: MD,MDd   # Ignoring MT and MTd
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,6 @@ jobs:
           CONAN_ARCHS: x86_64   # No need for x86
           CONAN_VISUAL_RUNTIMES: MD,MDd   # Ignoring MT and MTd
         run: |
-          conan remote add --insert 0 -f nrel https://conan.commercialbuildings.dev/artifactory/api/conan/openstudio
           bincrafters-package-tools --auto
 
       - name: Debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ if (INTEGRATED_CONAN)
     ruby_installer/2.7.3@bincrafters/stable
     # cant use bison/3.5.3 from CCI as it uses m4 which won't build with x86. So use bincrafters' still but explicitly add bin dir to PATH later
     # bison_installer/3.3.2@bincrafters/stable
-    bison/3.7.1
+    bison/3.7.6
     zlib/1.2.11
     ${CONAN_FFI}
     ${CONAN_LIBYAML}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(ExternalProject)
 
 option(INTEGRATED_CONAN "Use conan integrated into this CMake." ON)
 
-set(OPENSSL_VERSION "1.1.0l")
+set(OPENSSL_VERSION "1.1.1n")
 
 if (INTEGRATED_CONAN)
   ###############################################################################
@@ -222,20 +222,33 @@ if( UNIX )
   # brew install autoconf automake libtool
   # brew link autoconf automake libtool
 
+  if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
+    set(patchCommand PATCH_COMMAND pwd
+      && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.patch
+      && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.util.patch
+      && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/0002-patch-encoding-CP720.patch
+      && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/0003-YYUSE.patch ${EXTRA_PATCH}
+      && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/0004-GCC7_8_fix_link_flags.patch
+    )
+  else()
+    set(patchCommand PATCH_COMMAND pwd
+      && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.patch
+      && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.util.patch
+      && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/0002-patch-encoding-CP720.patch
+      && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/0003-YYUSE.patch ${EXTRA_PATCH}
+      # The 'nodynamic' modules patch fails to build in any way on Unix, with 2.5.x, so we aren't using it (at the moment anyhow)
+      # && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.nodynamic.patch
+    )
+  endif()
+
   set(configure_cmd "./configure --with-static-linked-ext --enable-load-relative ${MAC_opts} --disable-install-doc --prefix=${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install ${CONF_ARGS}")
   ExternalProject_Add(Ruby
     # Use official ruby source package to reduce dependencies on autoconf and friends
     URL https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.gz
     URL_HASH SHA256=6e5706d0d4ee4e1e2f883db9d768586b4d06567debea353c796ec45e8321c3d4
 
-    # The 'nodynamic' modules patch fails to build in any way on Unix, with 2.5.x, so we aren't using it (at the moment anyhow)
-    PATCH_COMMAND pwd
-      && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.patch
-      && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.util.patch
-      && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/0002-patch-encoding-CP720.patch
-      && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/0003-YYUSE.patch
+    ${patchCommand}
 
-      # && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.nodynamic.patch
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND pwd && sh -c "pwd && echo '===============  CONFIGURE ============' && echo 'Calling: ${configure_cmd}' && ${configure_cmd}"
     #    BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} Use default BUILD_COMMAND for now

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,7 +229,13 @@ if( UNIX )
     URL_HASH SHA256=6e5706d0d4ee4e1e2f883db9d768586b4d06567debea353c796ec45e8321c3d4
 
     # The 'nodynamic' modules patch fails to build in any way on Unix, with 2.5.x, so we aren't using it (at the moment anyhow)
-    PATCH_COMMAND pwd && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.patch && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.util.patch && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/0002-patch-encoding-CP720.patch# && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.nodynamic.patch
+    PATCH_COMMAND pwd
+      && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.patch
+      && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.util.patch
+      && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/0002-patch-encoding-CP720.patch
+      && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/0003-YYUSE.patch
+
+      # && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.nodynamic.patch
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND pwd && sh -c "pwd && echo '===============  CONFIGURE ============' && echo 'Calling: ${configure_cmd}' && ${configure_cmd}"
     #    BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} Use default BUILD_COMMAND for now
@@ -302,6 +308,7 @@ else()
                && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.win.272.patch  # && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.nodynamic.patch
                && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/0001-patch-to-support-version-ranges-for-MSVC.patch
                && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/0002-patch-encoding-CP720.patch
+               && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/0003-YYUSE.patch
                && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.util.patch
     CONFIGURE_COMMAND ""
     BUILD_COMMAND cmd /C "${CMAKE_BINARY_DIR}/build_ruby_$<CONFIG>.bat"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,92 +3,12 @@ cmake_policy(SET CMP0048 NEW)
 
 project(openstudio_ruby)
 
-
 include(ExternalProject)
 
-option(INTEGRATED_CONAN "Use conan integrated into this CMake." ON)
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 
-set(OPENSSL_VERSION "1.1.1o")
-
-if (INTEGRATED_CONAN)
-  ###############################################################################
-  # Conan
-
-  # Download automatically, you can also just copy the conan.cmake file
-  set(CMAKE_CONAN_EXPECTED_HASH 52a255a933397fdce3d0937f9c737e98)
-  set(CMAKE_CONAN_VERSION "0.17.0")
-
-  if(EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
-    file(MD5 "${CMAKE_BINARY_DIR}/conan.cmake" CMAKE_CONAN_HASH)
-  endif()
-  if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake" OR NOT "${CMAKE_CONAN_HASH}" MATCHES "${CMAKE_CONAN_EXPECTED_HASH}")
-    # Put it in CMAKE_BINARY_DIR so we don't end up with two when building OpenStudioApplication
-    message(STATUS "openstudio: Downloading conan.cmake ${CMAKE_CONAN_VERSION} from https://github.com/conan-io/cmake-conan")
-    file(DOWNLOAD "https://github.com/conan-io/cmake-conan/raw/${CMAKE_CONAN_VERSION}/conan.cmake"
-       "${CMAKE_BINARY_DIR}/conan.cmake")
-  else()
-    message(STATUS "openstudio: using existing conan.cmake")
-  endif()
-
-  include(${CMAKE_BINARY_DIR}/conan.cmake)
-
-  message("RUNNING CONAN")
-
-  conan_check(VERSION 1.43.0 REQUIRED)
-
-  # Add NREL remote and place it first in line, since we vendored dependencies to NREL's repo, they will be picked first
-  conan_add_remote(NAME nrel INDEX 0
-    URL https://conan.openstudio.net/artifactory/api/conan/openstudio)
-
-  conan_add_remote(NAME bincrafters
-    URL https://bincrafters.jfrog.io/artifactory/api/conan/public-conan)
-
-  set(CONAN_BUILD "missing")
-  list(APPEND CONAN_OPTIONS "gdbm:libgdbm_compat=True")
-  list(APPEND CONAN_OPTIONS "gdbm:with_libiconv=False")
-  list(APPEND CONAN_OPTIONS "gdbm:with_nls=False")
-
-  # Passing shared=False is fine (but also already the default)
-  # Passing fPIC=True is already the default on Unix, and doesn't exist on Windows (options is deleted in most recipes)
-  #list(APPEND CONAN_OPTIONS "libyaml:fPIC=True")
-  #list(APPEND CONAN_OPTIONS "libyaml:shared=False")
-  #list(APPEND CONAN_OPTIONS "gdbm:fPIC=True")
-  #list(APPEND CONAN_OPTIONS "gdbm:shared=False")
-  #list(APPEND CONAN_OPTIONS "readline:fPIC=True")
-  #list(APPEND CONAN_OPTIONS "readline:shared=False")
-  #list(APPEND CONAN_OPTIONS "fPIC=True")
-  #list(APPEND CONAN_OPTIONS "libffi:shared=False")
-
-  if(NOT MSVC)
-    set(CONAN_FFI "libffi/3.4.2")
-    set(CONAN_LIBYAML "libyaml/0.2.5")
-    set(CONAN_READLINE "readline/8.1.2")
-    list(APPEND CONAN_OPTIONS "gdbm:with_readline=True")
-    set(CONAN_GDBM "gdbm/1.19")
-    set(CONAN_GMP "gmp/6.2.1")
-  endif()
-
-  conan_cmake_run(REQUIRES
-    openssl/${OPENSSL_VERSION}
-    ruby_installer/2.7.3@bincrafters/stable
-    bison/3.7.6
-    zlib/1.2.12
-    ${CONAN_FFI}
-    ${CONAN_LIBYAML}
-    ${CONAN_READLINE}
-    ${CONAN_GDBM}
-    ${CONAN_GMP}
-
-    BASIC_SETUP CMAKE_TARGETS NO_OUTPUT_DIRS
-    GENERATORS cmake_find_package
-    BUILD ${CONAN_BUILD}
-    OPTIONS ${CONAN_OPTIONS}
-  )
-else()
-  include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-endif()
-
-
+# OPENSSL_VERSION is now set via conanfile.py
+message(AUTHOR_WARNING "OPENSSL_VERSION=${OPENSSL_VERSION}")
 
 find_package(Git)
 if(NOT GIT_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if (INTEGRATED_CONAN)
 
   message("RUNNING CONAN")
 
-  conan_check(VERSION 1.30.0 REQUIRED)
+  conan_check(VERSION 1.43.0 REQUIRED)
 
   # Add NREL remote and place it first in line, since we vendored dependencies to NREL's repo, they will be picked first
   conan_add_remote(NAME nrel INDEX 0
@@ -64,12 +64,12 @@ if (INTEGRATED_CONAN)
   #list(APPEND CONAN_OPTIONS "libffi:shared=False")
 
   if(NOT MSVC)
-    set(CONAN_FFI "libffi/3.3")
+    set(CONAN_FFI "libffi/3.4.2")
     set(CONAN_LIBYAML "libyaml/0.2.5")
     set(CONAN_READLINE "readline/8.0")
     list(APPEND CONAN_OPTIONS "gdbm:with_readline=True")
-    set(CONAN_GDBM "gdbm/1.18.1")
-    set(CONAN_GMP "gmp/6.2.0")
+    set(CONAN_GDBM "gdbm/1.19")
+    set(CONAN_GMP "gmp/6.2.1")
   endif()
 
   conan_cmake_run(REQUIRES
@@ -77,7 +77,7 @@ if (INTEGRATED_CONAN)
     ruby_installer/2.7.3@bincrafters/stable
     # cant use bison/3.5.3 from CCI as it uses m4 which won't build with x86. So use bincrafters' still but explicitly add bin dir to PATH later
     # bison_installer/3.3.2@bincrafters/stable
-    bison/3.7.1
+    bison/3.7.6
     zlib/1.2.11
     ${CONAN_FFI}
     ${CONAN_LIBYAML}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(ExternalProject)
 
 option(INTEGRATED_CONAN "Use conan integrated into this CMake." ON)
 
-set(OPENSSL_VERSION "1.1.1n")
+set(OPENSSL_VERSION "1.1.0l")
 
 if (INTEGRATED_CONAN)
   ###############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(ExternalProject)
 
 option(INTEGRATED_CONAN "Use conan integrated into this CMake." ON)
 
-set(OPENSSL_VERSION "1.1.0l")
+set(OPENSSL_VERSION "1.1.1m")
 
 if (INTEGRATED_CONAN)
   ###############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(ExternalProject)
 
 option(INTEGRATED_CONAN "Use conan integrated into this CMake." ON)
 
-set(OPENSSL_VERSION "1.1.1n")
+set(OPENSSL_VERSION "1.1.1o")
 
 if (INTEGRATED_CONAN)
   ###############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,7 +222,7 @@ if( UNIX )
   # brew install autoconf automake libtool
   # brew link autoconf automake libtool
 
-  set(configure_cmd "./configure --with-static-linked-ext --enable-load-relative ${MAC_opts} --disable-install-doc --prefix=${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install ${CONF_ARGS}")
+  set(configure_cmd "./configure --with-static-linked-ext --enable-load-relative ${MAC_opts} --disable-install-doc cflags=-fPIC --prefix=${CMAKE_BINARY_DIR}/Ruby-prefix/src/Ruby-install ${CONF_ARGS}")
   ExternalProject_Add(Ruby
     # Use official ruby source package to reduce dependencies on autoconf and friends
     URL https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.2.tar.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,10 +260,10 @@ else()
   #file(DOWNLOAD https://iweb.dl.sourceforge.net/project/gnuwin32/bison/2.4.1/bison-2.4.1-bin.zip ${CMAKE_BINARY_DIR}/tools/bison-2.4.1-bin.zip)
   #file(DOWNLOAD https://iweb.dl.sourceforge.net/project/gnuwin32/bison/2.4.1/bison-2.4.1-dep.zip ${CMAKE_BINARY_DIR}/tools/bison-2.4.1-dep.zip)
   if(NOT EXISTS ${CMAKE_BINARY_DIR}/tools/sed-4.2.1-dep.zip)
-    file(DOWNLOAD https://iweb.dl.sourceforge.net/project/gnuwin32/sed/4.2.1/sed-4.2.1-dep.zip ${CMAKE_BINARY_DIR}/tools/sed-4.2.1-dep.zip)
+    file(DOWNLOAD https://sourceforge.net/projects/gnuwin32/files/sed/4.2.1/sed-4.2.1-dep.zip ${CMAKE_BINARY_DIR}/tools/sed-4.2.1-dep.zip)
   endif()
   if(NOT EXISTS ${CMAKE_BINARY_DIR}/tools/sed-4.2.1-bin.zip)
-    file(DOWNLOAD https://iweb.dl.sourceforge.net/project/gnuwin32/sed/4.2.1/sed-4.2.1-bin.zip ${CMAKE_BINARY_DIR}/tools/sed-4.2.1-bin.zip)
+    file(DOWNLOAD https://sourceforge.net/projects/gnuwin32/files/sed/4.2.1/sed-4.2.1-bin.zip ${CMAKE_BINARY_DIR}/tools/sed-4.2.1-bin.zip)
   endif()
 
   #add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/tools/bin/bison.exe ${CMAKE_BINARY_DIR}/tools/bin/sed.exe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(ExternalProject)
 
 option(INTEGRATED_CONAN "Use conan integrated into this CMake." ON)
 
-set(OPENSSL_VERSION "1.1.1m")
+set(OPENSSL_VERSION "1.1.1n")
 
 if (INTEGRATED_CONAN)
   ###############################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,6 +290,7 @@ else()
   # tool dependencies
   ExternalProject_Add(Ruby
     #DEPENDS GetTools FFI
+    DEPENDS GetTools
     #    URL https://cache.ruby-lang.org/pub/ruby/2.5/ruby-2.5.5.tar.gz
     #    URL_HASH SHA256=28a945fdf340e6ba04fc890b98648342e3cccfd6d223a48f3810572f11b2514c
     URL https://codeload.github.com/ruby/ruby/tar.gz/v2_7_2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ if (INTEGRATED_CONAN)
     ruby_installer/2.7.3@bincrafters/stable
     # cant use bison/3.5.3 from CCI as it uses m4 which won't build with x86. So use bincrafters' still but explicitly add bin dir to PATH later
     # bison_installer/3.3.2@bincrafters/stable
-    bison/3.7.6
+    bison/3.7.1
     zlib/1.2.11
     ${CONAN_FFI}
     ${CONAN_LIBYAML}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ if( UNIX )
   # brew install autoconf automake libtool
   # brew link autoconf automake libtool
 
-  if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
+  if(CMAKE_COMPILER_IS_GNUCXX)
     set(patchCommand PATCH_COMMAND pwd
       && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.patch
       && ${PATCH_EXE} -p1 < ${CMAKE_SOURCE_DIR}/patches/Ruby.util.patch

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,10 +44,6 @@ if (INTEGRATED_CONAN)
     URL https://bincrafters.jfrog.io/artifactory/api/conan/public-conan)
 
   set(CONAN_BUILD "missing")
-  if (APPLE)
-    list(APPEND CONAN_BUILD "zlib")
-  endif()
-  list(APPEND CONAN_OPTIONS "zlib:minizip=True")
   list(APPEND CONAN_OPTIONS "gdbm:libgdbm_compat=True")
   list(APPEND CONAN_OPTIONS "gdbm:with_libiconv=False")
   list(APPEND CONAN_OPTIONS "gdbm:with_nls=False")
@@ -66,7 +62,7 @@ if (INTEGRATED_CONAN)
   if(NOT MSVC)
     set(CONAN_FFI "libffi/3.4.2")
     set(CONAN_LIBYAML "libyaml/0.2.5")
-    set(CONAN_READLINE "readline/8.0")
+    set(CONAN_READLINE "readline/8.1.2")
     list(APPEND CONAN_OPTIONS "gdbm:with_readline=True")
     set(CONAN_GDBM "gdbm/1.19")
     set(CONAN_GMP "gmp/6.2.1")
@@ -75,10 +71,8 @@ if (INTEGRATED_CONAN)
   conan_cmake_run(REQUIRES
     openssl/${OPENSSL_VERSION}
     ruby_installer/2.7.3@bincrafters/stable
-    # cant use bison/3.5.3 from CCI as it uses m4 which won't build with x86. So use bincrafters' still but explicitly add bin dir to PATH later
-    # bison_installer/3.3.2@bincrafters/stable
     bison/3.7.6
-    zlib/1.2.11
+    zlib/1.2.12
     ${CONAN_FFI}
     ${CONAN_LIBYAML}
     ${CONAN_READLINE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,10 +266,10 @@ else()
   #file(DOWNLOAD https://iweb.dl.sourceforge.net/project/gnuwin32/bison/2.4.1/bison-2.4.1-bin.zip ${CMAKE_BINARY_DIR}/tools/bison-2.4.1-bin.zip)
   #file(DOWNLOAD https://iweb.dl.sourceforge.net/project/gnuwin32/bison/2.4.1/bison-2.4.1-dep.zip ${CMAKE_BINARY_DIR}/tools/bison-2.4.1-dep.zip)
   if(NOT EXISTS ${CMAKE_BINARY_DIR}/tools/sed-4.2.1-dep.zip)
-    file(DOWNLOAD https://iweb.dl.sourceforge.net/project/gnuwin32/sed/4.2.1/sed-4.2.1-dep.zip ${CMAKE_BINARY_DIR}/tools/sed-4.2.1-dep.zip)
+    file(DOWNLOAD  https://sourceforge.net/projects/gnuwin32/files/sed/4.2.1/sed-4.2.1-dep.zip ${CMAKE_BINARY_DIR}/tools/sed-4.2.1-dep.zip)
   endif()
   if(NOT EXISTS ${CMAKE_BINARY_DIR}/tools/sed-4.2.1-bin.zip)
-    file(DOWNLOAD https://iweb.dl.sourceforge.net/project/gnuwin32/sed/4.2.1/sed-4.2.1-bin.zip ${CMAKE_BINARY_DIR}/tools/sed-4.2.1-bin.zip)
+    file(DOWNLOAD  https://sourceforge.net/projects/gnuwin32/files/sed/4.2.1/sed-4.2.1-bin.zip ${CMAKE_BINARY_DIR}/tools/sed-4.2.1-bin.zip)
   endif()
 
   #add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/tools/bin/bison.exe ${CMAKE_BINARY_DIR}/tools/bin/sed.exe

--- a/build.py
+++ b/build.py
@@ -55,12 +55,17 @@ if __name__ == "__main__":
     )
 
     # There's no reason to use Debug builds of the build_requirements at least
-    builder.update_build_if(lambda build: True,
-                            new_settings={
-                                "bison:build_type": "Release",
-                                "ruby_installer:build_type": "Release",
-                                "m4:build_type": "Release",
-                            })
+    builder.update_build_if(
+        lambda build: True,
+        new_settings={
+            "bison:build_type": "Release",
+            "ruby_installer:build_type": "Release",
+            "m4:build_type": "Release",
+        },
+        new_options={
+            "pcre:with_zlib": False,
+        },
+    )
 
     # This doesn"t work, it doesn't get passed to the docker container
     # build_profile_text = textwrap.dedent("""

--- a/build.py
+++ b/build.py
@@ -1,16 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# import os
-# import textwrap
-# import tempfile
-# from conans.util.files import save
 from cpt.printer import Printer
 from cpt.ci_manager import CIManager
 from bincrafters import build_template_default
 
-# Debug
-import glob as gb
 
 if __name__ == "__main__":
 
@@ -62,25 +56,7 @@ if __name__ == "__main__":
             "ruby_installer:build_type": "Release",
             "m4:build_type": "Release",
         },
-        # new_options={
-        #     "pcre:with_zlib": False,
-        # },
     )
-
-    # This doesn"t work, it doesn't get passed to the docker container
-    # build_profile_text = textwrap.dedent("""
-        # include(default)
-
-        # [settings]
-        # build_type=Release
-        # """)
-
-    # tmp = os.path.join(os.path.expanduser("~"), '.conan', 'profiles',
-                       # 'build_profile_release')
-    # abs_profile_build_path = os.path.abspath(tmp)
-    # save(abs_profile_build_path, build_profile_text)
-
-    # builder.run(base_profile_build_name=abs_profile_build_path)
 
     builder.run()
 
@@ -88,6 +64,7 @@ if __name__ == "__main__":
     # try:
     #     builder.run()
     # except:
+    #     import glob as gb
     #     for p in gb.glob(os.path.join(os.path.expanduser("~"), ".conan",
     #                                   "data", "bison", "**", "config.log"),
     #                      recursive=True):
@@ -99,4 +76,3 @@ if __name__ == "__main__":
     #         print("--------------------------------------------------------")
     #         print(content)
     #         print("========================================================")
-

--- a/build.py
+++ b/build.py
@@ -62,9 +62,9 @@ if __name__ == "__main__":
             "ruby_installer:build_type": "Release",
             "m4:build_type": "Release",
         },
-        new_options={
-            "pcre:with_zlib": False,
-        },
+        # new_options={
+        #     "pcre:with_zlib": False,
+        # },
     )
 
     # This doesn"t work, it doesn't get passed to the docker container

--- a/build.py
+++ b/build.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import os
-import textwrap
-import tempfile
-from conans.util.files import save
+# import os
+# import textwrap
+# import tempfile
+# from conans.util.files import save
 from cpt.printer import Printer
 from cpt.ci_manager import CIManager
 from bincrafters import build_template_default
@@ -55,25 +55,29 @@ if __name__ == "__main__":
     )
 
     # There's no reason to use Debug builds of the build_requirements at least
-    # builder.update_build_if(lambda build: True,
-    #                         new_settings={
-    #                             "bison:build_type": "Release",
-    #                             "ruby_installer:build_type": "Release",
-    #                         })
+    builder.update_build_if(lambda build: True,
+                            new_settings={
+                                "bison:build_type": "Release",
+                                "ruby_installer:build_type": "Release",
+                                "m4:build_type": "Release",
+                            })
 
-    build_profile_text = textwrap.dedent("""
-        include(default)
+    # This doesn"t work, it doesn't get passed to the docker container
+    # build_profile_text = textwrap.dedent("""
+        # include(default)
 
-        [settings]
-        build_type=Release
-        """)
+        # [settings]
+        # build_type=Release
+        # """)
 
-    tmp = os.path.join(os.path.expanduser("~"), '.conan', 'profiles',
-                       'build_profile_release')
-    abs_profile_build_path = os.path.abspath(tmp)
-    save(abs_profile_build_path, build_profile_text)
+    # tmp = os.path.join(os.path.expanduser("~"), '.conan', 'profiles',
+                       # 'build_profile_release')
+    # abs_profile_build_path = os.path.abspath(tmp)
+    # save(abs_profile_build_path, build_profile_text)
 
-    builder.run(base_profile_build_name=abs_profile_build_path)
+    # builder.run(base_profile_build_name=abs_profile_build_path)
+
+    builder.run()
 
     # Debug
     # try:

--- a/build.py
+++ b/build.py
@@ -2,6 +2,9 @@
 # -*- coding: utf-8 -*-
 
 import os
+import textwrap
+import tempfile
+from conans.util.files import save
 from cpt.printer import Printer
 from cpt.ci_manager import CIManager
 from bincrafters import build_template_default
@@ -58,7 +61,19 @@ if __name__ == "__main__":
     #                             "ruby_installer:build_type": "Release",
     #                         })
 
-    builder.run()
+    build_profile_text = textwrap.dedent("""
+        include(default)
+
+        [settings]
+        build_type=Release
+        """)
+
+    tmp = os.path.join(os.path.expanduser("~"), '.conan', 'profiles',
+                       'build_profile_release')
+    abs_profile_build_path = os.path.abspath(tmp)
+    save(abs_profile_build_path, build_profile_text)
+
+    builder.run(base_profile_build_name=abs_profile_build_path)
 
     # Debug
     # try:

--- a/conanfile.py
+++ b/conanfile.py
@@ -125,10 +125,7 @@ class OpenstudiorubyConan(ConanFile):
         pre-compiled binary, then the build requirements for this package will
         not be retrieved.
         """
-        if tools.os_info.linux_distro in ["centos"]:
-            self.build_requires("ruby_installer/2.7.3@nrel/centos")
-        else:
-            self.build_requires("ruby_installer/2.7.3@bincrafters/stable")
+        self.build_requires("ruby_installer/2.7.3@bincrafters/stable")
 
         # cant use bison/3.5.3 from CCI as it uses m4 which won't build
         # with x86. So use bincrafters' still but explicitly add bin dir

--- a/conanfile.py
+++ b/conanfile.py
@@ -64,12 +64,13 @@ class OpenstudiorubyConan(ConanFile):
         # I could let it slide, and hope for the best, but I'm afraid of other
         # incompatibilities, so just raise (which shouldn't happen when trying
         # to install from OpenStudio's cmake)
-        if (self.settings.compiler == 'gcc'):
-            if (self.settings.compiler.libcxx != "libstdc++11"):
-                msg = ("This isn't meant to be compiled with an old "
-                       " GCC ABI (though complation will work), "
-                       "please use settings.compiler.libcxx=libstdc++11")
-                raise ConanInvalidConfiguration(msg)
+        if tools.os_info.linux_distro not in ["centos"]:
+            if (self.settings.compiler == 'gcc'):
+                if (self.settings.compiler.libcxx != "libstdc++11"):
+                    msg = ("This isn't meant to be compiled with an old "
+                           " GCC ABI (though complation will work), "
+                           "please use settings.compiler.libcxx=libstdc++11")
+                    raise ConanInvalidConfiguration(msg)
 
         # I delete the libcxx setting now, so that the package_id isn't
         # calculated taking this into account.

--- a/conanfile.py
+++ b/conanfile.py
@@ -85,10 +85,9 @@ class OpenstudiorubyConan(ConanFile):
         Declare required dependencies
         """
         # Doesn't work with 3.x.
-        # Doesn't work on gcc 7 and 8 with 1.1.1n
+        # Doesn't work on gcc 7 and 8 with 1.1.1n: had to patch it
         self.requires("openssl/1.1.1n")
-        # Make sure you get a zlib post separation between zlib and minizip
-        self.requires("zlib/1.2.11#4b38406da00104befece594b529fd155")
+        self.requires("zlib/1.2.12")
 
         if self.options.with_libyaml:
             self.requires("libyaml/0.2.5")

--- a/conanfile.py
+++ b/conanfile.py
@@ -86,7 +86,7 @@ class OpenstudiorubyConan(ConanFile):
         """
         # Doesn't work with 3.x.
         # Doesn't work on gcc 7 and 8 with 1.1.1n
-        self.requires("openssl/1.1.0l")
+        self.requires("openssl/1.1.1n")
         # Make sure you get a zlib post separation between zlib and minizip
         self.requires("zlib/1.2.11#4b38406da00104befece594b529fd155")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -84,7 +84,7 @@ class OpenstudiorubyConan(ConanFile):
         """
         Declare required dependencies
         """
-        self.requires("openssl/1.1.0l") # fails with 1.1.1h https://github.com/openssl/openssl/issues/3884`
+        self.requires("openssl/1.1.1m")  # Doesn't work with 3.x
         # Make sure you get a zlib post separation between zlib and minizip
         self.requires("zlib/1.2.11#683857dbd5377d65f26795d4023858f9")
 
@@ -99,12 +99,6 @@ class OpenstudiorubyConan(ConanFile):
             # self.options["libffi"].fPIC = True
 
         if self.options.with_gdbm:
-            # NOTE: I have uploaded the gdbm/1.18.1 to the NREL remote
-            # with the status of this PR https://github.com/conan-io/conan-center-index/pull/2180
-            # at SHA https://github.com/conan-io/conan-center-index/pull/2180/commits/fad6b09ec294e8c0d186caea0c38bd6941dc0343
-            # So for now that'll only work if you have the NREL remote **before**
-            # the conan-center one...
-            # `conan remote update nrel https://api.bintray.com/conan/commercialbuilding/nrel --insert 0`
             self.requires("gdbm/1.19")
             # self.options["gdbm"].shared = False
             # self.options["gdbm"].fPIC = True

--- a/conanfile.py
+++ b/conanfile.py
@@ -86,7 +86,7 @@ class OpenstudiorubyConan(ConanFile):
         """
         self.requires("openssl/1.1.0l") # fails with 1.1.1h https://github.com/openssl/openssl/issues/3884`
         # Make sure you get a zlib post separation between zlib and minizip
-        self.requires("zlib/1.2.11#683857dbd5377d65f26795d4023858f9")
+        self.requires("zlib/1.2.12")
 
         if self.options.with_libyaml:
             self.requires("libyaml/0.2.5")
@@ -163,7 +163,13 @@ class OpenstudiorubyConan(ConanFile):
         # for patch in self.conan_data["patches"][self.version]:
         #     tools.patch(**patch)
 
-        cmake = CMake(self)
+        parallel = True
+        if tools.os_info.linux_distro in ["centos"]:
+            # parallel=False required or MFLAGS = -s --jobserver-fds=3,4 -j
+            # is strapped and centos' make is too old to understand
+            parallel = False
+
+        cmake = CMake(self, parallel=parallel)
         cmake.definitions["INTEGRATED_CONAN"] = False
         cmake.configure()
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -86,7 +86,7 @@ class OpenstudiorubyConan(ConanFile):
         """
         # Doesn't work with 3.x.
         # Doesn't work on gcc 7 and 8 with 1.1.1n: had to patch it
-        self.requires("openssl/1.1.1n")
+        self.requires("openssl/1.1.1o")
         self.requires("zlib/1.2.12")
 
         if self.options.with_libyaml:

--- a/conanfile.py
+++ b/conanfile.py
@@ -144,7 +144,7 @@ class OpenstudiorubyConan(ConanFile):
         # redefinition errors in Ruby' parser.c
         # Latest bison with m4/1.4.18
         # self.build_requires("bison/3.7.1#dcffa3dd9204cb79ac7ca09a7f19bb8b")
-        self.build_requires("bison/3.7.6")
+        self.build_requires("bison/3.7.1")
 
     def build(self):
         """

--- a/conanfile.py
+++ b/conanfile.py
@@ -84,9 +84,9 @@ class OpenstudiorubyConan(ConanFile):
         """
         Declare required dependencies
         """
-        self.requires("openssl/1.1.1m")  # Doesn't work with 3.x
+        self.requires("openssl/1.1.1n")  # Doesn't work with 3.x
         # Make sure you get a zlib post separation between zlib and minizip
-        self.requires("zlib/1.2.11#683857dbd5377d65f26795d4023858f9")
+        self.requires("zlib/1.2.11#4b38406da00104befece594b529fd155")
 
         if self.options.with_libyaml:
             self.requires("libyaml/0.2.5")
@@ -109,7 +109,7 @@ class OpenstudiorubyConan(ConanFile):
                 self.options["gdbm"].with_readline = True
 
         if self.options.with_readline:
-            self.requires("readline/8.0")
+            self.requires("readline/8.1.2")
             # self.options["readline"].shared = True
             # self.options["readline"].fPIC = True
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -125,7 +125,7 @@ class OpenstudiorubyConan(ConanFile):
         pre-compiled binary, then the build requirements for this package will
         not be retrieved.
         """
-        self.build_requires("ruby_installer/2.7.3@bincrafters/stable")
+        self.build_requires("ruby_installer/2.7.3@nrel/stable")
 
         # cant use bison/3.5.3 from CCI as it uses m4 which won't build
         # with x86. So use bincrafters' still but explicitly add bin dir

--- a/conanfile.py
+++ b/conanfile.py
@@ -144,7 +144,7 @@ class OpenstudiorubyConan(ConanFile):
         # redefinition errors in Ruby' parser.c
         # Latest bison with m4/1.4.18
         # self.build_requires("bison/3.7.1#dcffa3dd9204cb79ac7ca09a7f19bb8b")
-        self.build_requires("bison/3.7.1")
+        self.build_requires("bison/3.7.6")
 
     def build(self):
         """

--- a/conanfile.py
+++ b/conanfile.py
@@ -152,7 +152,7 @@ class OpenstudiorubyConan(ConanFile):
         # Latest bison with m4/1.4.18
         # self.build_requires("bison/3.7.1#dcffa3dd9204cb79ac7ca09a7f19bb8b")
         # The one on NREL (older)
-        self.build_requires("bison/3.7.1#ad29e804e82c8b6d58765096676b5a5e")
+        self.build_requires("bison/3.7.1")
 
     def build(self):
         """

--- a/conanfile.py
+++ b/conanfile.py
@@ -94,7 +94,7 @@ class OpenstudiorubyConan(ConanFile):
             # self.options["libyaml"].fPIC = True
 
         if self.options.with_libffi:
-            self.requires("libffi/3.3")
+            self.requires("libffi/3.4.2")
             # self.options["libffi"].shared = False
             # self.options["libffi"].fPIC = True
 
@@ -105,7 +105,7 @@ class OpenstudiorubyConan(ConanFile):
             # So for now that'll only work if you have the NREL remote **before**
             # the conan-center one...
             # `conan remote update nrel https://api.bintray.com/conan/commercialbuilding/nrel --insert 0`
-            self.requires("gdbm/1.18.1")
+            self.requires("gdbm/1.19")
             # self.options["gdbm"].shared = False
             # self.options["gdbm"].fPIC = True
             self.options["gdbm"].libgdbm_compat = True
@@ -120,7 +120,7 @@ class OpenstudiorubyConan(ConanFile):
             # self.options["readline"].fPIC = True
 
         if self.options.with_gmp:
-            self.requires("gmp/6.2.0")
+            self.requires("gmp/6.2.1")
 
     def build_requirements(self):
         """
@@ -150,8 +150,7 @@ class OpenstudiorubyConan(ConanFile):
         # redefinition errors in Ruby' parser.c
         # Latest bison with m4/1.4.18
         # self.build_requires("bison/3.7.1#dcffa3dd9204cb79ac7ca09a7f19bb8b")
-        # The one on NREL (older)
-        self.build_requires("bison/3.7.1#8bba3cd5416cf47dbc99130108ecb67e")
+        self.build_requires("bison/3.7.6")
 
     def build(self):
         """

--- a/conanfile.py
+++ b/conanfile.py
@@ -130,7 +130,10 @@ class OpenstudiorubyConan(ConanFile):
         pre-compiled binary, then the build requirements for this package will
         not be retrieved.
         """
-        self.build_requires("ruby_installer/2.7.3@bincrafters/stable")
+        if tools.os_info.linux_distro in ["centos"]:
+            self.build_requires("ruby_installer/2.7.3@nrel/centos")
+        else:
+            self.build_requires("ruby_installer/2.7.3@bincrafters/stable")
 
         # cant use bison/3.5.3 from CCI as it uses m4 which won't build
         # with x86. So use bincrafters' still but explicitly add bin dir

--- a/conanfile.py
+++ b/conanfile.py
@@ -86,7 +86,7 @@ class OpenstudiorubyConan(ConanFile):
         """
         self.requires("openssl/1.1.0l") # fails with 1.1.1h https://github.com/openssl/openssl/issues/3884`
         # Make sure you get a zlib post separation between zlib and minizip
-        self.requires("zlib/1.2.11#683857dbd5377d65f26795d4023858f9")
+        self.requires("zlib/1.2.12")
 
         if self.options.with_libyaml:
             self.requires("libyaml/0.2.5")

--- a/conanfile.py
+++ b/conanfile.py
@@ -84,7 +84,9 @@ class OpenstudiorubyConan(ConanFile):
         """
         Declare required dependencies
         """
-        self.requires("openssl/1.1.1n")  # Doesn't work with 3.x
+        # Doesn't work with 3.x.
+        # Doesn't work on gcc 7 and 8 with 1.1.1n
+        self.requires("openssl/1.1.0l")
         # Make sure you get a zlib post separation between zlib and minizip
         self.requires("zlib/1.2.11#4b38406da00104befece594b529fd155")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -152,7 +152,7 @@ class OpenstudiorubyConan(ConanFile):
         # Latest bison with m4/1.4.18
         # self.build_requires("bison/3.7.1#dcffa3dd9204cb79ac7ca09a7f19bb8b")
         # The one on NREL (older)
-        self.build_requires("bison/3.7.1#8bba3cd5416cf47dbc99130108ecb67e")
+        self.build_requires("bison/3.7.1#ad29e804e82c8b6d58765096676b5a5e")
 
     def build(self):
         """

--- a/conanfile.py
+++ b/conanfile.py
@@ -165,7 +165,7 @@ class OpenstudiorubyConan(ConanFile):
             parallel = False
 
         cmake = CMake(self, parallel=parallel)
-        cmake.definitions["INTEGRATED_CONAN"] = False
+        cmake.definitions["OPENSSL_VERSION"] = self.deps_cpp_info["openssl"].version
         cmake.configure()
 
         # On Windows the build never succeeds on the first try. Much effort

--- a/patches/0003-YYUSE.patch
+++ b/patches/0003-YYUSE.patch
@@ -1,0 +1,12 @@
+diff --git a/parse.y b/parse.y
+index 0fd0c46..97c9743 100644
+--- a/parse.y
++++ b/parse.y
+@@ -12673,7 +12673,6 @@ count_char(const char *str, int c)
+ RUBY_FUNC_EXPORTED size_t
+ rb_yytnamerr(struct parser_params *p, char *yyres, const char *yystr)
+ {
+-    YYUSE(p);
+     if (*yystr == '"') {
+ 	size_t yyn = 0, bquote = 0;
+ 	const char *yyp = yystr;

--- a/patches/0004-GCC7_8_fix_link_flags.patch
+++ b/patches/0004-GCC7_8_fix_link_flags.patch
@@ -1,0 +1,28 @@
+diff --git a/template/Makefile.in b/template/Makefile.in
+index 3845f02..5822e80 100644
+--- a/template/Makefile.in
++++ b/template/Makefile.in
+@@ -271,7 +271,22 @@ miniruby$(EXEEXT):
+ $(PROGRAM):
+ 		@$(RM) $@
+ 		$(ECHO) linking $@
+-		$(Q) $(PURIFY) $(CC) $(LDFLAGS) $(XLDFLAGS) $(MAINOBJ) $(EXTOBJS) $(LIBRUBYARG) $(MAINLIBS) $(LIBS) $(EXTLIBS) $(OUTFLAG)$@
++		$(ECHO) Q = $(Q)
++		$(ECHO) PURIFY = $(PURIFY)
++		$(ECHO) CC = $(CC)
++		$(ECHO) LDFLAGS = $(LDFLAGS)
++		$(ECHO) XLDFLAGS = $(XLDFLAGS)
++		$(ECHO) MAINOBJ = $(MAINOBJ)
++		$(ECHO) EXTOBJS = $(EXTOBJS)
++		$(ECHO) LIBRUBYARG = $(LIBRUBYARG)
++		$(ECHO) MAINLIBS = $(MAINLIBS)
++		$(ECHO) LIBS = $(LIBS)
++		$(ECHO) EXTLIBS = $(EXTLIBS)
++		$(ECHO) OUTFLAG = $(OUTFLAG)
++		$(ECHO) POSTLINK = $(POSTLINK)
++		$(ECHO) ORIGINAL LINK FLAGS =  $(LIBRUBYARG) $(MAINLIBS) $(LIBS) $(EXTLIBS)
++		$(ECHO) NEW LINK FLAGS = -Wl,-rpath,$(libdir) -lruby-static -lz -lrt -lgmp -ldl -lcrypt -lm -lanl -lssl -lcrypto -lreadline -lncurses -lgdbm_compat -lgdbm -lffi -lutil -lyaml -pthread
++		$(Q) $(PURIFY) $(CC) $(LDFLAGS) $(XLDFLAGS) $(MAINOBJ) $(EXTOBJS) -Wl,-rpath,$(libdir) -lruby-static -lz -lrt -lgmp -ldl -lcrypt -lm -lanl -lssl -lcrypto -lreadline -lncurses -lgdbm_compat -lgdbm -lffi -lutil -lyaml -pthread $(OUTFLAG)$@
+ 		$(Q) $(POSTLINK)
+ 
+ PRE_LIBRUBY_UPDATE = [ -n "$(LIBRUBY_SO_UPDATE)" ] || $(gnumake:yes=exec) $(RM) $(LIBRUBY_EXTS)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -68,6 +68,8 @@ get_filename_component(SWIG_BIN_DIR ${SWIG_EXECUTABLE} DIRECTORY)
 set(SWIG_DIR "${SWIG_BIN_DIR}/swiglib")
 message(STATUS "set SWIG_DIR=${SWIG_DIR}")
 
+message(WARNING "SWIG_EXECUTABLE=${SWIG_EXECUTABLE}, SWIG_LIB=${SWIG_LIB}")
+
 #######################################################################
 #                               G E M S                               #
 #######################################################################

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -21,7 +21,7 @@ class TestPackageConan(ConanFile):
         """
         Declare required dependencies for testing
         """
-        self.requires("minizip/1.2.11")  # depends on zlib/1.2.11
+        self.requires("minizip/1.2.12")  # depends on zlib/1.2.12
 
     def build_requirements(self):
         """

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -64,7 +64,7 @@ class TestPackageConan(ConanFile):
 
             rel_path = os.path.relpath(test_file, start=self.build_folder)
 
-            with open(test_file, 'r') as f:
+            with open(test_file, 'r', encoding='utf-8') as f:
                 content = f.read()
             single_tests = re_test.findall(content)
             if not single_tests:


### PR DESCRIPTION
On Ubuntu 18.04 (and Centos7) when using GCC-10 it won't link (similar to the GCC7 and GCC8 runners for which I originally created the patch that reorders ruby's superbly wrong link flags order. This is actually because (once more) of GLIBC differences: the conan runners gcc7 for eg is based on Artful (17.10), the 8 is Bionic (18.04), 9 is Eoan (19.10), 10 and 11 are Focal (20.04)

cf https://github.com/conan-io/conan-docker-tools/blob/3f59cb379c0e43097a7685c74b44ae7a3676c0f7/legacy/gcc_7/Dockerfile#L1

So this aims to try and fix that by applying the same patch to all GCC versions

```
linking ruby
/root/.conan/data/openssl/1.1.1o/_/_/package/19729b9559f3ae196cad45cb2b97468ccb75dcd1/lib/libcrypto.a(threads_pthread.o): In function `fork_once_func':
threads_pthread.c:(.text+0x16): undefined reference to `pthread_atfork'
collect2: error: ld returned 1 exit status
Makefile:275: recipe for target 'ruby' failed
make[5]: *** [ruby] Error 1
exts.mk:163: recipe for target 'ruby' failed
make[4]: *** [ruby] Error 2
uncommon.mk:295: recipe for target 'build-ext' failed
make[3]: *** [build-ext] Error 2
CMakeFiles/Ruby.dir/build.make:86: recipe for target 'Ruby-prefix/src/Ruby-stamp/Ruby-build' failed
make[2]: *** [Ruby-prefix/src/Ruby-stamp/Ruby-build] Error 2
CMakeFiles/Makefile2:82: recipe for target 'CMakeFiles/Ruby.dir/all' failed
make[1]: *** [CMakeFiles/Ruby.dir/all] Error 2
Makefile:90: recipe for target 'all' failed
```
