### PR TITLE
Hotfixes for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,11 +74,11 @@ jobs:
           allow_failure: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: "0"
 
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,11 +94,11 @@ jobs:
 
           # Use lowercase based on repository owner, so that NREL -> nrel.
           # That should work on forks, while not replacing 'nrel' with '***' everywhere like it does when you set CONAN_USERNAME as a repo secret...
-          # We want BPT/CPT to produces openstudio_ruby/2.7.2@<CONAN_USERNAME>/<channel>
+          # We want BPT/CPT to produces openstudio_ruby/3.1.3@<CONAN_USERNAME>/<channel>
           CONAN_USERNAME=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           echo "CONAN_USERNAME=$CONAN_USERNAME" >> $GITHUB_ENV
 
-          matrix="{\"name\": \"${{ matrix.build_name }}\", \"compiler\": \"${{ matrix.compiler }}\", \"version\": \"${{ matrix.version}}\", \"dockerImage\": \"${{ matrix.CONAN_DOCKER_IMAGE }}\", \"cwd\": \"./\", \"recipe_version\": \"2.7.2\"}"
+          matrix="{\"name\": \"${{ matrix.build_name }}\", \"compiler\": \"${{ matrix.compiler }}\", \"version\": \"${{ matrix.version}}\", \"dockerImage\": \"${{ matrix.CONAN_DOCKER_IMAGE }}\", \"cwd\": \"./\", \"recipe_version\": \"3.1.3\"}"
           bincrafters-package-tools prepare-env --platform gha --config "${matrix}"
       - name: Run
         env:
@@ -123,7 +123,7 @@ jobs:
           set -x
 
           echo "=========== MAKEFILE ================"
-          find ~/.conan/data/openstudio_ruby/2.7.2/$CONAN_USERNAME/testing/build -name "Makefile"|while read fname; do
+          find ~/.conan/data/openstudio_ruby/3.1.3/$CONAN_USERNAME/testing/build -name "Makefile"|while read fname; do
             echo "============== $fname ============"
             cat $fname
             echo ""
@@ -133,7 +133,7 @@ jobs:
 
           #if [[ "$(uname -s)" == 'Darwin' ]]; then
           echo "=========== RUBY MKMF.LOG ================"
-          find ~/.conan/data/openstudio_ruby/2.7.2/$CONAN_USERNAME/testing/build -name "mkmf.log"|while read fname; do
+          find ~/.conan/data/openstudio_ruby/3.1.3/$CONAN_USERNAME/testing/build -name "mkmf.log"|while read fname; do
             echo "============== $fname ============"
             cat $fname
             echo ""
@@ -160,7 +160,7 @@ jobs:
           #done || true
 
           echo "=========== RUBY CONFIG.LOG ================"
-          find ~/.conan/data/openstudio_ruby/2.7.2/$CONAN_USERNAME/testing/build -name "config.log"|while read fname; do
+          find ~/.conan/data/openstudio_ruby/3.1.3/$CONAN_USERNAME/testing/build -name "config.log"|while read fname; do
             echo "============== $fname ============"
             cat $fname
             echo ""
@@ -169,7 +169,7 @@ jobs:
           done || true
 
           echo "=========== RUBY CONFIG.STATUS ================"
-          find ~/.conan/data/openstudio_ruby/2.7.2/$CONAN_USERNAME/testing/build -name "config.status"|while read fname; do
+          find ~/.conan/data/openstudio_ruby/3.1.3/$CONAN_USERNAME/testing/build -name "config.status"|while read fname; do
             echo "============== $fname ============"
             cat $fname
             echo ""

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,31 +27,26 @@ jobs:
           compiler: GCC
           version: 7
           allow_failure: false
-          CONAN_DOCKER_IMAGE: conanio/gcc7:1.46.2
         - build_name: GCC-8
           os: ubuntu-18.04
           compiler: GCC
           version: 8
           allow_failure: false
-          CONAN_DOCKER_IMAGE: conanio/gcc8:1.46.2
         - build_name: GCC-9
           os: ubuntu-18.04
           compiler: GCC
           version: 9
           allow_failure: false
-          CONAN_DOCKER_IMAGE: conanio/gcc9:1.46.2
         - build_name: GCC-10
           os: ubuntu-18.04
           compiler: GCC
           version: 10
           allow_failure: false
-          CONAN_DOCKER_IMAGE: conanio/gcc10:1.46.2
         - build_name: GCC-11
           os: ubuntu-18.04
           compiler: GCC
           version: 11
           allow_failure: false
-          CONAN_DOCKER_IMAGE: conanio/gcc11:1.46.2
         - build_name: Apple-Clang 11
           os: macos-10.15
           compiler: APPLE_CLANG

--- a/build.py
+++ b/build.py
@@ -3,8 +3,7 @@
 
 from cpt.printer import Printer
 from cpt.ci_manager import CIManager
-from bincrafters import build_template_default
-
+from bincrafters import build_autodetect
 
 if __name__ == "__main__":
 
@@ -38,7 +37,7 @@ if __name__ == "__main__":
     # cf: https://docs.conan.io/en/latest/howtos/manage_gcc_abi.html
     pure_c = False
 
-    builder = build_template_default.get_builder(
+    builder = build_autodetect._get_default_builder(
         build_policy="outdated",
         upload_only_when_stable=upload_only_when_stable,
         pure_c=pure_c


### PR DESCRIPTION
I'm one of the maintainers of Bincrafters Package Tools that your CI setup is using.

One of the reasons it is currently broken is that you are using a custom `build.py` file that tries to import files that are gone since [Bincrafters Package Tools 0.33.0 ](https://github.com/bincrafters/bincrafters-package-tools/releases/tag/0.33.0)

This PR applies a hotfix